### PR TITLE
compose-file.rst: environment: "not" converted to True or False

### DIFF
--- a/compose/compose-file.rst
+++ b/compose/compose-file.rst
@@ -450,7 +450,7 @@ environment
 
 .. Add environment variables. You can use either an array or a dictionary. Any boolean values; true, false, yes no, need to be enclosed in quotes to ensure they are not converted to True or False by the YML parser.
 
-環境変数を追加します。配列もしくは辞書形式（dictionary）で指定できます。boolean 値は true、false、yes、no のいずれかであり、YML パーサによって True か False に変換されるよう、クォート（ ' 記号）で囲む必要があります。
+環境変数を追加します。配列もしくは辞書形式（dictionary）で指定できます。boolean 値 (true、false、yes、no のいずれか) は、YML パーサによって True か False に変換されないよう、クォート（ ' 記号）で囲む必要があります。
 
 .. Environment variables with only a key are resolved to their values on the machine Compose is running on, which can be helpful for secret or host-specific values.
 


### PR DESCRIPTION
もとの日本語（「変換されるよう」の部分）のみを読んでいたら文意がつかめなかったのですが、
英語版を読んで not converted とかかれていることに気付いたので、その修正をご報告いたします。

また、「boolean 値は……のいずれかであり、」という部分も、まるで
環境変数が boolean 値を持つ場合について積極的に説明しているかのように見えてしまったので、
そこについてもあわせて微修正をさせていただきました。ご検討いただければと思います。
