### PR TITLE
Docs アーカイブが空になっているのを修正

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -200,8 +200,7 @@ Docs archive
 .. toctree::
    :maxdepth: 1
    :caption: Docs アーカイブ
-  
-..   v1.13 <http://docs.docker.jp/v1.13/>
+
    v1.12 <http://docs.docker.jp/v1.12/>
    v1.11 <http://docs.docker.jp/v1.11/>
    v1.10 <http://docs.docker.jp/v1.10/>


### PR DESCRIPTION
v1.13 をコメントアウトしようとして Docs アーカイブの toctree 全体が無効になっているようです。
意図していない結果になっているように見えるので、このコメント行を削除してはいかがでしょうか。