### PR TITLE
Indices and tables を削除

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -206,12 +206,3 @@ Docs archive
    v1.11 <http://docs.docker.jp/v1.11/>
    v1.10 <http://docs.docker.jp/v1.10/>
    v1.9 <http://docs.docker.jp/v1.9/>
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
-


### PR DESCRIPTION
索引および Python モジュールインデックスを利用していないため、該当のブロックをまるごと削除しました。

現在、索引向けのマークアップが行われていないので、索引ページは空です。
http://docs.docker.jp/genindex.html

また、Python のモジュールが定義されていないので、Python モジュールインデックスはリンク切れになっています。
http://docs.docker.jp/py-modindex.html

※ これはどちらかというと Sphinx のデフォルトのドキュメントが間違っているような…

検索は有効で、使用可能ですが、現在使用しているテンプレートではサイドバーから検索ができるため、トップページの最下部にリンクが有ることに合理性はなさそうなので、セクションまるごと削除を提案します。