### PR TITLE
Fix char code

### DIFF
--- a/get-started/part2.rst
+++ b/get-started/part2.rst
@@ -139,6 +139,7 @@ Docker であれば、移動可能な Python ランタイムをイメージ内�
 * app.py
 
 .. code-block:: bash
+   # coding:utf-8
 
    from flask import Flask
    from redis import Redis, RedisError


### PR DESCRIPTION
`docker run -p 4000:80 friendlyhello`を実行すると文字コードエラーがでる

```
File "app.py", line 6
SyntaxError: Non-ASCII character '\xe3' in file app.py on line 6, but no encoding declare
d; see http://python.org/dev/peps/pep-0263/ for details
```