### PR TITLE
訳修正案 /engine/docker_overview

### DIFF
--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -424,10 +424,15 @@ Docker は `Go 言語 <https://golang.org/>`_ で書かれており、Linux カ�
 
 .. Namespaces
 
-名前空間（namespaces）
+名前空間
 ------------------------------
 
-.. Docker takes advantage of a technology called namespaces to provide the isolated workspace we call the container. When you run a container, Docker creates a set of namespaces for that container.
+.. Docker uses a technology called `namespaces` to provide the isolated workspace
+   called the *container*. When you run a container, Docker creates a set of
+   *namespaces* for that container.
+
+Docker は名前空間という技術を利用して *コンテナ* と呼ぶ作業空間を分離して提供します。
+コンテナが実行されたとき、Docker はそのコンテナに対して複数の *名前空間* を生成します。
 
 .. Docker uses a technology called namespaces to provide the isolated workspace called the container. When you run a container, Docker creates a set of namespaces for that container.
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -185,10 +185,10 @@ Docker の可搬性と軽量な特性は、以下のようなことを容易に�
 それは処理負荷を動的に管理できること、ビジネスシーンでの要求に応じてアプリケーションのスケールアップや提供終了を簡単に、しかもほぼリアルタイムで行うことができます。
 
 
-.. Running more workloads on the same hardware
+.. **Running more workloads on the same hardware**
 .. _running-more-workloads-on-the-same-hardware:
 
-同じハードウェア上でより多くの処理を実行
+同一ハードウェア上にて負荷の高い処理を実行
 ----------------------------------------
 
 .. Docker is lightweight and fast. It provides a viable, cost-effective alternative to hypervisor-based virtual machines, so you can use more of your compute capacity to achieve your business goals. Docker is perfect for high density environments and for small and medium deployments where you need to do more with fewer resources.

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -134,7 +134,7 @@ Docker の詳細については、 :ref:`docker-architecture` を参照してく
 .. Fast, consistent delivery of your applications
 .. _fast-consistent-delivery-of-your-applications:
 
-速く、一貫性のあるアプリケーションのデリバリ
+アプリケーションの配信をすばやく一貫性を保って
 --------------------------------------------------
 
 .. Docker streamlines the development lifecycle by allowing developers to work in standardized environments using local containers which provide your applications and services. Containers are great for continuous integration and continuous development (CI/CD) workflows.

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -101,9 +101,12 @@ Docker Engine は、主に以下の３つのコンポーネントからなるク
    :scale: 60%
    :alt: Docker Engine コンポーネント図
 
-.. The CLI uses the Docker REST API to control or interact with the Docker daemon through scripting or direct CLI commands. Many other Docker applications use the underlying API and CLI
+.. The CLI uses the Docker REST API to control or interact with the Docker daemon
+   through scripting or direct CLI commands. Many other Docker applications use the
+   underlying API and CLI.
 
-CLI は Docker REST API を使い、Docker デーモンに対してスクリプトや CLI コマンドを通して、 Docker デーモンを制御または操作をします。多くの他の Docker アプリケーションも、水面下では API と CLI を利用します。
+CLI は Docker REST API を通じて、スクリプトや直接のコマンド実行により Docker デーモンを制御したり入出力を行ったりします。
+Docker アプリケーションの多くが、基本的なところで API や CLI を利用しています。
 
 .. The daemon creates and manages Docker objects, such as images, containers, networks, and volumes.
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -417,9 +417,10 @@ Docker Engine がスウォームモードをサポートするのは Docker バ�
 基盤とする技術
 ==============
 
-.. Docker is written in Go and makes use of several kernel features to deliver the functionality we’ve seen.
+.. Docker is written in [Go](https://golang.org/) and takes advantage of several
+   features of the Linux kernel to deliver its functionality.
 
-Docker は `Go 言語 <https://golang.org/>`_ で書かれており、これまで見てきた機能は、カーネルが持つ複数の機能を利用しています。
+Docker は `Go 言語 <https://golang.org/>`_ で書かれており、Linux カーネルの機能をうまく活用して、さまざまな機能性を実現しています。
 
 .. Namespaces
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -434,9 +434,11 @@ Docker は `Go 言語 <https://golang.org/>`_ で書かれており、Linux カ�
 Docker は名前空間という技術を利用して *コンテナ* と呼ぶ作業空間を分離して提供します。
 コンテナが実行されたとき、Docker はそのコンテナに対して複数の *名前空間* を生成します。
 
-.. These namespaces provide a layer of isolation. Each aspect of a container runs in a separate namespace and its access is limited to that namespace.
+.. These namespaces provide a layer of isolation. Each aspect of a container runs
+   in a separate namespace and its access is limited to that namespace.
 
-名前空間はレイヤの分離ををもたらします。コンテナを実行した状態では、それぞれの名前空間は隔てられており、名前空間へのアクセスが制限されます。
+名前空間はいくつもの分離状態を作り出します。
+コンテナ内のさまざまな処理は、分離された名前空間内にて実行され、それぞれへのアクセスはその名前空間内に限定されます。
 
 .. Docker Engine uses namespaces such as the following on Linux:
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -459,14 +459,20 @@ Docker Engine が取り扱う名前空間は、Linux 上で言えば以下のよ
 * **mnt 名前区間** ：ファイルシステムのマウント・ポイントの管理。（MNT：マウント）
 * **uts 名前区間** ：カーネルとバージョンの分離。（UTS：Unix  Timesharing System、Unix タイムシェアリング・システム）
 
-.. Control groups
+.. ### Control groups
 
 コントロール・グループ (Control groups)
 ----------------------------------------
 
-.. Docker Engine on Linux also relies on another technology called control groups (cgroups). A cgroup limits an application to a specific set of resources. Control groups allow Docker Engine to share available hardware resources to containers and optionally enforce limits and constraints. For example, you can limit the memory available to a specific container.
+.. Docker Engine on Linux also relies on another technology called _control groups_
+   (`cgroups`). A cgroup limits an application to a specific set of resources.
+   Control groups allow Docker Engine to share available hardware resources to
+   containers and optionally enforce limits and constraints. For example,
+   you can limit the memory available to a specific container.
 
-Linux の Docker Engine はコントロール・グループ（ ``ctroups`` ）という他の技術も依存します。アプリケーションに対するリソース指定は cgroup で制限します。コントロール・グループにより、 Docker Engine のコンテナに対するハードウェア・リソース共有を可能とします。また、オプションでリソース上限や制限（constraint）も強制できます。たとえば、特定のコンテナに対する利用可能なメモリを制限できます。
+Linux 上で動作する Docker Engine には、さらに *コントール・グループ* （``cgroups``; control groups）と呼ばれる技術も併用されます。
+cgroup は、アプリケーションが利用するリソースを特定のものに限定します。
+つまりコントロール・グループは、Docker Engine が利用可能なハードウェア・リソースをコンテナ間で共有するようにし、必要に応じて利用上限や制約をつけることも行います。たとえば特定のコンテナが利用するメモリの上限を設定することもできます。
 
 .. Union file systems
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -83,15 +83,17 @@ Docker Engine
 
 .. Docker Engine is a client-server application with these major components:
 
-Docker Engine は３つの主なコンポーネント（構成要素）を持つクライアント・サーバ型アプリケーションです。
+Docker Engine は、主に以下の３つのコンポーネントからなるクライアントサーバ型アプリケーションです。
 
-..    A server which is a type of long-running program called a daemon process (the dockerd command).
-    A REST API which specifies interfaces that programs can use to talk to the daemon and instruct it what to do.
-    A command line interface (CLI) client (the docker command).
+.. * A server which is a type of long-running program called a daemon process (the
+     `dockerd` command).
+    * A REST API which specifies interfaces that programs can use to talk to the
+     daemon and instruct it what to do.
+   * A command line interface (CLI) client (the `docker` command).
 
-* サーバはデーモン・プロセス（ ``dockerd`` コマンド）と呼ばれる長期間実行するプログラムの状態
-* インターフェースを規定する REST API は、プログラムがデーモンと通信に使うものであり、何をするか指示
-* コマンドライン・インターフェース（CLI）クライアント（ ``docker`` コマンド）
+* サーバ。長時間稼動する種類のプログラムでありデーモン・プロセスと呼ばれる（ ``dockerd`` コマンド）。
+* REST API。プログラムとデーモンとの間での通信方法を定義し、何をなすべきかを指示する。
+* コマンドライン・インターフェース（command line interface; CLI）クライアント（ ``docker`` コマンド）。
 
 .. Docker Engine Components Flow
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -257,9 +257,16 @@ Docker クライアントは複数のデーモンと通信することができ�
 Docker レジストリ
 --------------------
 
-.. A Docker registry stores Docker images. Docker Hub and Docker Cloud are public registries that anyone can use, and Docker is configured to look for images on Docker Hub by default. You can even run your own private registry. If you use Docker Datacenter (DDC), it includes Docker Trusted Registry (DTR).
+.. A Docker _registry_ stores Docker images. Docker Hub and Docker Cloud are public
+   registries that anyone can use, and Docker is configured to look for images on
+   Docker Hub by default. You can even run your own private registry. If you use
+   Docker Datacenter (DDC), it includes Docker Trusted Registry (DTR).
 
-Docker レジストリ（ *registry* ）は Docker イメージを保管します。Docker Hub と Docker Cloud は公開レジストリであり、誰でも利用可能です。また、 Docker はデフォルトで Docker Hub のイメージを探すよう設定されています。それだけでなく、自分のプライベート・レジストリも使えます。もし Docker データセンタ（DDC）を利用するのであれば、Docker トラステッド・レジストリ（DTR）が含まれています。
+Docker レジストリは Docker イメージを保管します。
+Docker Hub と Docker Cloud は公開レジストリであり、誰でも利用可能です。
+また  Docker はデフォルトで Docker Hub のイメージを探すよう設定されています。
+独自にプライベート・レジストリを運用することもできます。
+もし Docker データセンタ（Docker Datacenter; DDC）を利用するのであれば、Docker トラステッド・レジストリ（Docker Trusted Registry; DTR）が含まれています。
 
 .. When you use the docker pull or docker run commands, the required images are pulled from your configured registry. When you use the docker push command, your image is pushed to your configured registry.
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -137,9 +137,14 @@ Docker の詳細については、 :ref:`docker-architecture` を参照してく
 アプリケーションの配信をすばやく一貫性を保って
 --------------------------------------------------
 
-.. Docker streamlines the development lifecycle by allowing developers to work in standardized environments using local containers which provide your applications and services. Containers are great for continuous integration and continuous development (CI/CD) workflows.
+.. Docker streamlines the development lifecycle by allowing developers to work in
+   standardized environments using local containers which provide your applications
+   and services. Containers are great for continuous integration and continuous
+   development (CI/CD) workflows.
 
-Docker の開発ライフサイクルが効率的なのは、開発者がローカルなコンテナが提供するアプリケーションやサービスを通し、標準的な環境で作業できるからです。コンテナは継続的インテグレーションと継続できデプロイメント（CI/CD）ワークフローに最適です。
+Docker は開発のライフサイクルを効率化します。
+開発するアプリケーションやサービスがローカルなコンテナ内に実現でき、開発者は標準化された環境により作業が進められるからです。
+コンテナを使った開発は、継続的インテグレーション (continuous integration; CI) や継続的開発 (continuous development; CD) のワークフローに適しています。
 
 .. Consider the following example scenario:
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -150,15 +150,19 @@ Docker は開発のライフサイクルを効率化します。
 
 以下のようなシナリオ例を考えてみてください。
 
-..    Your developers write code locally and share their work with their colleagues using Docker containers.
-    They use Docker to push their applications into a test environment and execute automated and manual tests.
-    When developers find bugs, they can fix them in the development environment and redeploy them to the test environment for testing and validation.
-    When testing is complete, getting the fix to the customer is as simple as pushing the updated image to the production environment.
+.. - Your developers write code locally and share their work with their colleagues
+     using Docker containers.
+   - They use Docker to push their applications into a test environment and execute
+     automated and manual tests.
+   - When developers find bugs, they can fix them in the development environment
+     and redeploy them to the test environment for testing and validation.
+   - When testing is complete, getting the fix to the customer is as simple as
+     pushing the updated image to the production environment.
 
-* 開発者がローカルでコードを書き、同僚と作業時に共有するために Docker コンテナを使う
-* アプリケーションをテスト環境への送信や、自動実行、手動テストのために Docker を使う
-* 開発者がバグを発見したら、開発環境で問題を修正し、テストと確認のためにテスト環境に再デプロイする
-* テストが完了したら、プロダクション環境に単純に送信し、イメージを入れ替えるだけで、利用者は修正版を利用できる
+* 開発者がローカルでコードを書き、仲間とその作業を共有するために Docker コンテナを使います。
+* Docker によりアプリケーションをテスト環境に投入し、自動および手動のテストを実行します。
+* 開発者がバグを発見したら、開発環境においてこれを修正して、アプリケーションをテスト環境に再デプロイし、テスト確認を行ないます。
+* テストが完了します。この後にユーザが修正版を利用できるようにすることは、更新済イメージを本番環境へ投入することと同じく容易なことです。
 
 .. Responsive deployment and scaling
 .. _responsive-deployment-and-scaling:

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -170,9 +170,12 @@ Docker は開発のライフサイクルを効率化します。
 迅速なデプロイとスケーリング
 ----------------------------------------
 
-.. Docker’s container-based platform allows for highly portable workloads. Docker containers can run on a developer’s local laptop, on physical or virtual machines in a data center, on cloud providers, or in a mixture of environments.
+.. Docker's container-based platform allows for highly portable workloads. Docker
+   containers can run on a developer's local laptop, on physical or virtual
+   machines in a data center, on cloud providers, or in a mixture of environments.
 
-Docker はコンテナをベースとしたプラットフォームのため、移動性の高い処理（highly portable workloads）を行えます。Docker コンテナは開発者のローカル PC 上で実行できるだけでなく、データセンタの物理あるいは仮想マシン、クラウドプロバイダ、あるいは様々な環境の組み合わせにおいても実行可能です。
+Docker によるコンテナベースのプラットフォームは、処理負荷の高度な分散を考慮しています。
+Docker コンテナは、開発者のノートパソコン上で実行できるだけでなく、データセンタの物理マシンや仮想マシン、クラウドプロバイダ、そしてさまざまな環境の組み合わせにおいて実行可能です。
 
 .. Docker’s portability and lightweight nature also make it easy to dynamically manage workloads, scaling up or tearing down applications and services as business needs dictate, in near real time.
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -434,10 +434,6 @@ Docker は `Go 言語 <https://golang.org/>`_ で書かれており、Linux カ�
 Docker は名前空間という技術を利用して *コンテナ* と呼ぶ作業空間を分離して提供します。
 コンテナが実行されたとき、Docker はそのコンテナに対して複数の *名前空間* を生成します。
 
-.. Docker uses a technology called namespaces to provide the isolated workspace called the container. When you run a container, Docker creates a set of namespaces for that container.
-
-Docker は名前空間（ネームスペース）と呼ばれる技術を利用し、*コンテナ （container）* と呼ぶワークスペース（作業空間）の分離をもたらします。コンテナの実行時、Docker はコンテナに *名前空間* の集まりを作成します。
-
 .. These namespaces provide a layer of isolation. Each aspect of a container runs in a separate namespace and its access is limited to that namespace.
 
 名前空間はレイヤの分離ををもたらします。コンテナを実行した状態では、それぞれの名前空間は隔てられており、名前空間へのアクセスが制限されます。

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -444,17 +444,20 @@ Docker は名前空間という技術を利用して *コンテナ* と呼ぶ作
 
 Docker Engine が取り扱う名前空間は、Linux 上で言えば以下のようなものです。
 
-..    The pid namespace: Process isolation (PID: Process ID).
-    The net namespace: Managing network interfaces (NET: Networking).
-    The ipc namespace: Managing access to IPC resources (IPC: InterProcess Communication).
-    The mnt namespace: Managing filesystem mount points (MNT: Mount).
-    The uts namespace: Isolating kernel and version identifiers. (UTS: Unix Timesharing System).
+..  - **The `pid` namespace:** Process isolation (PID: Process ID).
+    - **The `net` namespace:** Managing network interfaces (NET:
+    Networking).
+    - **The `ipc` namespace:** Managing access to IPC
+    resources (IPC: InterProcess Communication).
+    - **The `mnt` namespace:** Managing filesystem mount points (MNT: Mount).
+    - **The `uts` namespace:** Isolating kernel and version identifiers. (UTS: Unix
+   Timesharing System).
 
-* **pid 名前区間** ：プロセスの分離に使います（PID：プロセス ID）
-* **net 名前区間** ：ネットワーク・インターフェースの管理に使います（NET：ネットワーキング）
-* **ipc 名前区間** ：IPC リソースに対するアクセス管理に使います（IPC：InterProcess Communication、内部プロセスの通信）
-* **mnt 名前区間** ：マウント・ポイントの管理に使います（MNT：マウント）
-* **uts 名前区間** ：カーネルとバージョン認識の隔離に使います（UTS：Unix  Timesharing System、Unix タイムシェアリング・システム）
+* **pid 名前区間** ：プロセスの分離。（PID：プロセス ID）
+* **net 名前区間** ：ネットワーク・インターフェースの管理。（NET：ネットワーキング）
+* **ipc 名前区間** ：IPC リソースに対するアクセス管理。（IPC：InterProcess Communication、内部プロセスの通信）
+* **mnt 名前区間** ：ファイルシステムのマウント・ポイントの管理。（MNT：マウント）
+* **uts 名前区間** ：カーネルとバージョンの分離。（UTS：Unix  Timesharing System、Unix タイムシェアリング・システム）
 
 .. Control groups
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -490,12 +490,17 @@ Docker Engine では AUFS、btrfs、vfs、DeviceMapper などの UnionFS 系の�
 
 .. Container format
 
-コンテナの形式（フォーマット）
+コンテナ・フォーマット
 ------------------------------
 
-.. Docker Engine combines the namespaces, control groups, and UnionFS into a wrapper called a container format. The default container format is libcontainer. In the future, Docker may support other container formats by integrating with technologies such as BSD Jails or Solaris Zones.
+.. Docker Engine combines the namespaces, control groups, and UnionFS into a wrapper
+   called a container format. The default container format is `libcontainer`. In
+   the future, Docker may support other container formats by integrating with
+   technologies such as BSD Jails or Solaris Zones.
 
-Docker Engine は名前空間、コントロールグループ、UnionFS を連結し、包み込んでいます。これをコンテナ形式（フォーマット）と呼びます。デフォルトのコンテナ形式は ``libcontainer`` と呼ばれています。いずれ、Docker は他のコンテナ形式、例えば BSD Jail や Solaris Zone との統合をサポートするかもしれません。
+名前空間、コントロール・グループ、UnionFS は Docker Engine により、コンテナ・フォーマットと呼ばれるラッパーとして構成されます。
+このコンテナ・フォーマットのデフォルトが ``libcontainer`` です。
+いずれ BSD Jail や Solaris Zone などを技術統合した新たなコンテナ・フォーマットがサポートされることになるかもしれません。
 
 .. Next steps
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -108,9 +108,11 @@ Docker Engine は、主に以下の３つのコンポーネントからなるク
 CLI は Docker REST API を通じて、スクリプトや直接のコマンド実行により Docker デーモンを制御したり入出力を行ったりします。
 Docker アプリケーションの多くが、基本的なところで API や CLI を利用しています。
 
-.. The daemon creates and manages Docker objects, such as images, containers, networks, and volumes.
+.. The daemon creates and manages Docker _objects_, such as images, containers,
+   networks, and volumes.
 
-デーモンは Docker オブジェクトを作成・管理します。Docker オブジェクトとは、イメージ、コンテナ、ネットワーク、データ・ボリューム等です。
+デーモンは Docker オブジェクトを作成、管理します。
+Docker オブジェクトとは、イメージ、コンテナー、ネットワーク、データ・ボリュームなどです。
 
 ..    Note: Docker is licensed under the open source Apache 2.0 license.
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -41,9 +41,21 @@ Docker が採用する方法を最大限利用して、アプリケーション�
 Docker プラットフォーム
 ==============================
 
-.. Docker provides the ability to package and run an application in a loosely isolated environment called a container. The isolation and security allow you to run many containers simultaneously on a given host. Containers are lightweight because they don’t need the extra load of a hypervisor, but run directly within the host machine’s kernel. This means you can run more containers on a given hardware combination than if you were using virtual machines. You can even run Docker containers within host machines that are actually virtual machines!
+.. Docker provides the ability to package and run an application in a loosely isolated
+   environment called a container. The isolation and security allow you to run many
+   containers simultaneously on a given host. Containers are lightweight because
+   they don’t need the extra load of a hypervisor, but run directly within the host
+   machine’s kernel. This means you can run more containers on a given hardware
+   combination than if you were using virtual machines. You can even run Docker
+   containers within host machines that are actually virtual machines!
 
-Docker が提供するのは、コンテナ（container）と呼ばれる緩やかに隔離された環境 [#f1]_ における、アプリケーションの梱包（パッケージ）と実行です。隔離とセキュリティにより、指定したホスト上で多くのコンテナを一斉に実行できます。コンテナは外部のハイパーバイザによる処理が不要です。そして、コンテナはホストマシン上のカーネル内で直接実行しますので、軽量です。つまり、任意のハードウェアの組み合わせにより、仮想マシンの使用よりも多くのコンテナを実行できます。また、Docker コンテナの実行はホストマシンだけでなく、実際には仮想マシン上でも実行できるのです！
+Docker はアプリケーションをパッケージ化して実行するために、ほぼ分離された環境となるコンテナというものを提供します。
+隔離してセキュリティを保つことから、実行するホスト上に複数のコンテナを同時に実行することができます。
+コンテナは非常に軽量なものとなります。
+なぜならハイパーバイザーを別途ロードする必要などなく、ホストマシンのカーネルを使って動作するからです。
+このことは手元にあるハードウェアの中から、必要なものを使ってより多くのコンテナが実行できることを意味します。
+それは仮想マシンを使う以上のことです。
+さらに Docker コンテナを動作させるホストマシンは、それ自体が仮想マシンであっても構わないのです。
 
 .. Docker provides tooling and a platform to manage the lifecycle of your containers:
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -191,10 +191,16 @@ Docker の可搬性と軽量な特性は、以下のようなことを容易に�
 同一ハードウェア上にて負荷の高い処理を実行
 ----------------------------------------
 
-.. Docker is lightweight and fast. It provides a viable, cost-effective alternative to hypervisor-based virtual machines, so you can use more of your compute capacity to achieve your business goals. Docker is perfect for high density environments and for small and medium deployments where you need to do more with fewer resources.
+.. Docker is lightweight and fast. It provides a viable, cost-effective alternative
+   to hypervisor-based virtual machines, so you can use more of your compute
+   capacity to achieve your business goals. Docker is perfect for high density
+   environments and for small and medium deployments where you need to do more with
+   fewer resources.
 
-Docker は軽量かつ高速です。これはハイパーバイザーをベースとした仮想化マシンよりも、費用対効果を高くします。そのため、皆さんの計算能力を、ビジネスにおけるゴールに到達するために利用できるのです。Docker が最適なのは、高密度の環境や、より少ないリソースを必要とする中小規模のデプロイです。
-
+Docker は軽量かつ高速です。
+ハイパーバイザ・ベースの仮想マシンに取って変わる、実用的で費用対効果の高いものです。
+したがってコンピュータ性能をフルに活用してビジネス目標を達成できます。
+Docker は高度に処理集中する環境に適しており、さらには中小規模の、より少ないリソースの中でのシステム構築にも適しています。
 
 .. Docker architecture
 .. _docker-architecture:

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -412,10 +412,10 @@ Dockerfile の内容を書き換えたことでイメージが再構築される
 利用者からすると、Docker サービスは１つのアプリケーションとして見えます。
 Docker Engine がスウォームモードをサポートするのは Docker バージョン 1.12 またはそれ以上です。
 
-.. The underlying technology
+.. ## The underlying technology
 
-基礎技術
-==========
+基盤とする技術
+==============
 
 .. Docker is written in Go and makes use of several kernel features to deliver the functionality we’ve seen.
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -341,9 +341,13 @@ Dockerfile の内容を書き換えたことでイメージが再構築される
 デフォルトでは、コンテナは他のコンテナやホストマシンとは、程よく分離されています。
 コンテナに属するネットワーク、ストレージ、基盤となるサブシステムなどを、いかにして他のコンテナやホストマシンから切り離すか、その程度は制御することが可能です。
 
-.. A container is defined by its image as well as any configuration options you provide to it when you create or run it. When a container is removed, any changes to its state that are not stored in persistent storage disappear.
+.. A container is defined by its image as well as any configuration options you
+   provide to it when you create or run it. When a container is removed, any changes to
+   its state that are not stored in persistent storage disappear.
 
-コンテナはイメージによってデフォルトで定義されている設定だけでなく、コンテナを作成して実行する時にオプションの指定も可能です。コンテナを削除しますと、永続ストレージに保存していない変更や状態は消滅します。
+コンテナはイメージによって定義されるものです。
+またこれを生成、実行するために設定したオプションによっても定義されます。
+コンテナを削除すると、その時点での状態に対して変更がかかっていたとしても、永続的なストレージに保存されていないものは消失します。
 
 .. Example docker run command
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -241,9 +241,16 @@ Docker デーモン（ ``dockerd`` ）は Docker API リクエストを受け付
 Docker クライアント
 --------------------
 
-.. The Docker client (docker) is the primary way that many Docker users interact with Docker. When you use commands such as docker run, the client sends these commands to dockerd, which carries them out. The docker command uses the Docker API. The Docker client can communicate with more than one daemon.
+.. The Docker client (`docker`) is the primary way that many Docker users interact
+   with Docker. When you use commands such as `docker run`, the client sends these
+   commands to `dockerd`, which carries them out. The `docker` command uses the
+   Docker API. The Docker client can communicate with more than one daemon.
 
-Docker クライアント（ ``docker`` ）は多くの Docker 利用者が Docker を操作する主な手法です。 ``docker run`` のようなコマンドを用いると、クライアントは ``dockerd`` に命令（コマンド）を送り届けます。 ``dockerd`` コマンドは Docker API を用います。Docker クライアントは複数のデーモンと通信できます。
+Docker クライアント（ ``docker`` ）は Docker とのやりとりを行うために、たいていのユーザが利用するものです。
+``docker run`` のようなコマンドが実行されると、Docker クライアントは ``dockerd`` にそのコマンドを伝えます。
+そして ``dockerd`` はその内容を実現します。
+``docker`` コマンドは Docker API を利用しています。
+Docker クライアントは複数のデーモンと通信することができます。
 
 .. _docker-registries:
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -208,9 +208,18 @@ Docker は高度に処理集中する環境に適しており、さらには中�
 Docker のアーキテクチャ
 ==============================
 
-.. Docker uses a client-server architecture. The Docker client talks to the Docker daemon, which does the heavy lifting of building, running, and distributing your Docker containers. The Docker client and daemon can run on the same system, or you can connect a Docker client to a remote Docker daemon. The Docker client and daemon communicate using a REST API, over UNIX sockets or a network interface.
+.. Docker uses a client-server architecture. The Docker *client* talks to the
+   Docker *daemon*, which does the heavy lifting of building, running, and
+   distributing your Docker containers. The Docker client and daemon *can*
+   run on the same system, or you can connect a Docker client to a remote Docker
+   daemon. The Docker client and daemon communicate using a REST API, over UNIX
+   sockets or a network interface.
 
-Docker はクライアント・サーバ型のアーキテクチャです。Docker *クライアント* が Docker コンテナの構築・実行・配布といった力仕事をするには、 Docker *デーモン* と通信します。 Docker クライアントとデーモンは、どちらも同じシステム上で実行できます。また、Docker クライアントはリモートの Docker デーモンにも接続できます。Docker クライアントとデーモンは、お互いに UNIX ソケットやネットワーク・インターフェースを通し、 RESTful API を使って通信します。
+Docker はクライアント・サーバ型のアーキテクチャを採用しています。
+Docker *クライアント* は Docker デーモンに処理を依頼します。
+このデーモンは、Docker コンテナの構築、実行、配布という複雑な仕事をこなします。
+Docker クライアントとデーモンは同一システム上で動かすことも *可能* ですが、別のシステム上であっても、Docker クライアントからリモートにある Docker デーモンへのアクセスが可能です。
+Docker クライアントとデーモンの間の通信には REST API が利用され、UNIX ソケットまたはネット・ワークインターフェイスを介して行われます。
 
 .. image:: ./article-img/architecture.png
    :scale: 60%

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -324,9 +324,14 @@ Dockerfile の内容を書き換えたことでイメージが再構築される
 コンテナ
 ^^^^^^^^^^
 
-.. A container is a runnable instance of an image. You can create, run, stop, move, or delete a container using the Docker API or CLI. You can connect a container to one or more networks, attach storage to it, or even create a new image based on its current state.
+.. A container is a runnable instance of an image. You can create, run, stop,
+   move, or delete a container using the Docker API or CLI. You can connect a
+   container to one or more networks, attach storage to it, or even create a new
+   image based on its current state.
 
-コンテナ（container）とは、イメージの実行可能なインスタンス（訳者注；実体の意味）です。Docker API や CLI を使い、コンテナの作成、実行、停止、移動、削除を行えます。コンテナはネットワークに接続可能であり、ストレージもアタッチできます。あるいは、現在の状態を元にして新しいイメージの作成もできます。
+コンテナとは、イメージが実行状態となったインスタンスのことです。
+コンテナに対する生成、実行、停止、移動、削除は Docker API や CLI を使って行われます。
+コンテナは、複数のネットワークへの接続、ストレージの追加を行うことができ、さらには現時点の状態にもとづいた新たなイメージを生成することもできます。
 
 .. By default, a container is relatively well isolated from other containers and its host machine. You can control how isolated a container’s network, storage, or other underlying subsystems are from other containers or from the host machine.
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -371,14 +371,16 @@ Dockerfile の内容を書き換えたことでイメージが再構築される
        configured registry, as though you had run `docker pull ubuntu` manually.
    2.  Docker creates a new container, as though you had run a `docker create`
        command manually.
-    Docker allocates a read-write filesystem to the container, as its final layer. This allows a running container to create or modify files and directories in its local filesystem.
+   3.  Docker allocates a read-write filesystem to the container, as its final
+       layer. This allows a running container to create or modify files and
+       directories in its local filesystem.
     Docker creates a network interface to connect the container to the default network, since you did not specify any networking options. This includes assigning an IP address to the container. By default, containers can connect to external networks using the host machine’s network connection.
     Docker starts the container and executes /bin/bash. Because the container is run interactively and attached to your terminal (due to the -i and -t) flags, you can provide input using your keyboard and output is logged to your terminal.
     When you type exit to terminate the /bin/bash command, the container stops but is not removed. You can start it again or remove it.
 
 1. ``ubuntu`` イメージがローカルになければ、Docker は設定されているレジストリからイメージを取得します。この動作は手動で ``docker pull ubuntu`` を実行するのと同じです。
 2. Docker は新しいコンテナを生成します。これは手動で ``docker create`` コマンドを実行することと同じです。
-3. 読み書き可能なファイルシステムを、Docker はコンテナに新しいレイヤとして割り当てます。
+3. Docker はコンテナに対して読み書きが可能なファイルシステムを割り当てます。これが最終的にレイヤとなります。このことによりコンテナの稼動中に、ローカルなファイルシステム内でのファイルやディレクトリの生成や変更などが実現されます。
 4. Docker はネットワーク・インターフェースを作成し、ネットワークのオプション指定がなければ、コンテナをデフォルト・ネットワークに接続します。この時、コンテナに IP アドレスを割り当てます。ホストマシンのネットワークと接続するネットワークを使わなければ、コンテナはデフォルトで外部のネットワークと接続できません。
 5. Docker はコンテナを起動し、 ``/bin/bash`` を実行します。コンテナを双方向（interactive）かつターミナル（terminal）に接続する設定（ ``-i`` と ``-t`` のフラグによる）で実行しているため、キーボードを使っての入力や、出力をターミナルに表示できます。
 6. ``exit`` を入力すると、 ``/bin/bash`` コマンドは終了し、コンテナは停止状態となりますが、削除はされていません。コンテナを再起動するか、削除できます。

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -369,14 +369,15 @@ Dockerfile の内容を書き換えたことでイメージが再構築される
 
 .. 1.  If you do not have the `ubuntu` image locally, Docker pulls it from your
        configured registry, as though you had run `docker pull ubuntu` manually.
-   Docker creates a new container, as though you had run a docker create command manually.
+   2.  Docker creates a new container, as though you had run a `docker create`
+       command manually.
     Docker allocates a read-write filesystem to the container, as its final layer. This allows a running container to create or modify files and directories in its local filesystem.
     Docker creates a network interface to connect the container to the default network, since you did not specify any networking options. This includes assigning an IP address to the container. By default, containers can connect to external networks using the host machine’s network connection.
     Docker starts the container and executes /bin/bash. Because the container is run interactively and attached to your terminal (due to the -i and -t) flags, you can provide input using your keyboard and output is logged to your terminal.
     When you type exit to terminate the /bin/bash command, the container stops but is not removed. You can start it again or remove it.
 
 1. ``ubuntu`` イメージがローカルになければ、Docker は設定されているレジストリからイメージを取得します。この動作は手動で ``docker pull ubuntu`` を実行するのと同じです。
-2. Docker は新しいコンテナを作成します。こちらは手動で ``docker create`` コマンドを実行するのと同じです。
+2. Docker は新しいコンテナを生成します。これは手動で ``docker create`` コマンドを実行することと同じです。
 3. 読み書き可能なファイルシステムを、Docker はコンテナに新しいレイヤとして割り当てます。
 4. Docker はネットワーク・インターフェースを作成し、ネットワークのオプション指定がなければ、コンテナをデフォルト・ネットワークに接続します。この時、コンテナに IP アドレスを割り当てます。ホストマシンのネットワークと接続するネットワークを使わなければ、コンテナはデフォルトで外部のネットワークと接続できません。
 5. Docker はコンテナを起動し、 ``/bin/bash`` を実行します。コンテナを双方向（interactive）かつターミナル（terminal）に接続する設定（ ``-i`` と ``-t`` のフラグによる）で実行しているため、キーボードを使っての入力や、出力をターミナルに表示できます。

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -177,9 +177,12 @@ Docker は開発のライフサイクルを効率化します。
 Docker によるコンテナベースのプラットフォームは、処理負荷の高度な分散を考慮しています。
 Docker コンテナは、開発者のノートパソコン上で実行できるだけでなく、データセンタの物理マシンや仮想マシン、クラウドプロバイダ、そしてさまざまな環境の組み合わせにおいて実行可能です。
 
-.. Docker’s portability and lightweight nature also make it easy to dynamically manage workloads, scaling up or tearing down applications and services as business needs dictate, in near real time.
+.. Docker's portability and lightweight nature also make it easy to dynamically
+   manage workloads, scaling up or tearing down applications and services as
+   business needs dictate, in near real time.
 
-また、Docker の移動性と軽量な特性により、ビジネスにおける必要性に応じ、ほぼリアルタイムでアプリケーションやサービスをスケールアップ（拡張）やティアダウン（解体）するといった、動的な処理の管理を行いやすくします。
+Docker の可搬性と軽量な特性は、以下のようなことを容易に実現します。
+それは処理負荷を動的に管理できること、ビジネスシーンでの要求に応じてアプリケーションのスケールアップや提供終了を簡単に、しかもほぼリアルタイムで行うことができます。
 
 
 .. Running more workloads on the same hardware

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -442,7 +442,7 @@ Docker は名前空間という技術を利用して *コンテナ* と呼ぶ作
 
 .. Docker Engine uses namespaces such as the following on Linux:
 
-Docker Engine が使う Linux 上の名前空間は、次の通りです。
+Docker Engine が取り扱う名前空間は、Linux 上で言えば以下のようなものです。
 
 ..    The pid namespace: Process isolation (PID: Process ID).
     The net namespace: Managing network interfaces (NET: Networking).

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -378,14 +378,17 @@ Dockerfile の内容を書き換えたことでイメージが再構築される
        network, since you did not specify any networking options. This includes
        assigning an IP address to the container. By default, containers can
        connect to external networks using the host machine's network connection.
-    Docker starts the container and executes /bin/bash. Because the container is run interactively and attached to your terminal (due to the -i and -t) flags, you can provide input using your keyboard and output is logged to your terminal.
+   5.  Docker starts the container and executes `/bin/bash`. Because the container
+       is run interactively and attached to your terminal (due to the `-i` and `-t`)
+       flags, you can provide input using your keyboard and output is logged to
+       your terminal.
     When you type exit to terminate the /bin/bash command, the container stops but is not removed. You can start it again or remove it.
 
 1. ``ubuntu`` イメージがローカルになければ、Docker は設定されているレジストリからイメージを取得します。この動作は手動で ``docker pull ubuntu`` を実行するのと同じです。
 2. Docker は新しいコンテナを生成します。これは手動で ``docker create`` コマンドを実行することと同じです。
 3. Docker はコンテナに対して読み書きが可能なファイルシステムを割り当てます。これが最終的にレイヤとなります。このことによりコンテナの稼動中に、ローカルなファイルシステム内でのファイルやディレクトリの生成や変更などが実現されます。
 4. Docker はネットワーク・インターフェースを生成し、コンテナをデフォルト・ネットワークに接続します。ここではネットワーク・オプションを指定していないものとしているためです。このときには、コンテナに対しての IP アドレスの割り当ても行われます。デフォルトでコンテナは、ホストマシンのネットワーク接続を利用して、外部ネットワークに接続します。
-5. Docker はコンテナを起動し、 ``/bin/bash`` を実行します。コンテナを双方向（interactive）かつターミナル（terminal）に接続する設定（ ``-i`` と ``-t`` のフラグによる）で実行しているため、キーボードを使っての入力や、出力をターミナルに表示できます。
+5. Docker はコンテナを起動し、 ``/bin/bash`` を実行します。（ ``-i`` と ``-t`` のフラグにより）対話的に、かつターミナル画面に接続するようにして実行しているため、手元のキーボードを使って入力することができ、ターミナル画面に出力が行われるようになります。
 6. ``exit`` を入力すると、 ``/bin/bash`` コマンドは終了し、コンテナは停止状態となりますが、削除はされていません。コンテナを再起動するか、削除できます。
 
 サービス

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -114,11 +114,11 @@ Docker アプリケーションの多くが、基本的なところで API や C
 デーモンは Docker オブジェクトを作成、管理します。
 Docker オブジェクトとは、イメージ、コンテナー、ネットワーク、データ・ボリュームなどです。
 
-..    Note: Docker is licensed under the open source Apache 2.0 license.
+.. > **Note**: Docker is licensed under the open source Apache 2.0 license.
 
 .. note::
 
-   Docker のライセンスは、オープンソース Apache 2.0 ライセンスの下で供与されています。
+   Docker は、オープンソース Apache 2.0 ライセンスのもとで提供されています。
 
 Docker の詳細についれは、 :ref:`docker-architecture` をお読みください。
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -333,9 +333,13 @@ Dockerfile の内容を書き換えたことでイメージが再構築される
 コンテナに対する生成、実行、停止、移動、削除は Docker API や CLI を使って行われます。
 コンテナは、複数のネットワークへの接続、ストレージの追加を行うことができ、さらには現時点の状態にもとづいた新たなイメージを生成することもできます。
 
-.. By default, a container is relatively well isolated from other containers and its host machine. You can control how isolated a container’s network, storage, or other underlying subsystems are from other containers or from the host machine.
+.. By default, a container is relatively well isolated from other containers and
+   its host machine. You can control how isolated a container's network, storage,
+   or other underlying subsystems are from other containers or from the host
+   machine.
 
-デフォルトでは、コンテナは他のコンテナやホストマシンとの間で、相対的に分離（isolated）されています。コンテナのネットワークやストレージ、他のサブシステムを、その他のコンテナやホストマシンからどのように分離するかを制御できます。
+デフォルトでは、コンテナは他のコンテナやホストマシンとは、程よく分離されています。
+コンテナに属するネットワーク、ストレージ、基盤となるサブシステムなどを、いかにして他のコンテナやホストマシンから切り離すか、その程度は制御することが可能です。
 
 .. A container is defined by its image as well as any configuration options you provide to it when you create or run it. When a container is removed, any changes to its state that are not stored in persistent storage disappear.
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -148,7 +148,7 @@ Docker は開発のライフサイクルを効率化します。
 
 .. Consider the following example scenario:
 
-以下のシナリオ例が考えられます：
+以下のようなシナリオ例を考えてみてください。
 
 ..    Your developers write code locally and share their work with their colleagues using Docker containers.
     They use Docker to push their applications into a test environment and execute automated and manual tests.

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -306,9 +306,20 @@ Docker の利用時は、イメージ、コンテナ、ネットワーク、ボ�
 そこには Apache ウェブ・サーバや自開発したアプリケーションといったものをインストールするかもしれません。
 さらにアプリケーション実行に必要となる詳細な設定も加えることにもなるでしょう。
 
-.. You might create your own images or you might only use those created by others and published in a registry. To build your own image, you create a Dockerfile with a simple syntax for defining the steps needed to create the image and run it. Each instruction in a Dockerfile creates a layer in the image. When you change the Dockerfile and rebuild the image, only those layers which have changed are rebuilt. This is part of what makes images so lightweight, small, and fast, when compared to other virtualization technologies.
+.. You might create your own images or you might only use those created by others
+   and published in a registry. To build your own image, you create a _Dockerfile_
+   with a simple syntax for defining the steps needed to create the image and run
+   it. Each instruction in a Dockerfile creates a layer in the image. When you
+   change the Dockerfile and rebuild the image, only those layers which have
+   changed are rebuilt. This is part of what makes images so lightweight, small,
+   and fast, when compared to other virtualization technologies.
 
-イメージは自分で作成できますし、あるいはレジストリに公開されている他人が作ったイメージも利用できます。自分でイメージを構築するには、イメージを作成するために必要なステップを簡単な構文で定義する ``Dockerfile`` を作成し、実行します。Dockerfile の命令ごとに、イメージのレイヤ（layer）を作成します。Dockerfile を変更してイメージを再構築しても、変更のあったレイヤのみを再構築します。他の仮想化技術と比較した時に、この部分こそが、イメージの何が軽量で、小さく、速いのかにあたります。
+イメージは作ろうと思えば作ることができ、他の方が作ってレジストリに公開されているイメージを使うということもできます。
+イメージを自分で作る場合は Dockerfile というファイルを生成します。
+このファイルの文法は単純なものであり、そこにはイメージを生成して実行するまでの手順が定義されます。
+Dockerfile 内の個々の命令ごとに、イメージ内にはレイヤというものが生成されます。
+Dockerfile の内容を書き換えたことでイメージが再構築されるときには、変更がかかったレイヤのみが再生成されます。
+他の仮想化技術に比べて Dockerイメージというものが軽量、小さい、早いを実現できているのも、そういった部分があるからです。
 
 コンテナ
 ^^^^^^^^^^

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -479,9 +479,14 @@ cgroup は、アプリケーションが利用するリソースを特定のも�
 ユニオン・ファイル・システム
 ------------------------------
 
-.. Union file systems, or UnionFS, are file systems that operate by creating layers, making them very lightweight and fast. Docker Engine uses UnionFS to provide the building blocks for containers. Docker Engine can use multiple UnionFS variants, including AUFS, btrfs, vfs, and DeviceMapper.
+.. Union file systems, or UnionFS, are file systems that operate by creating layers,
+   making them very lightweight and fast. Docker Engine uses UnionFS to provide
+   the building blocks for containers. Docker Engine can use multiple UnionFS variants,
+   including AUFS, btrfs, vfs, and DeviceMapper.
 
-ユニオン・ファイル・システム、あるいは UnionFS はファイルシステムです。これは作成したレイヤを操作しますので、非常に軽量かつ高速です。Docker Engine はコンテナごとブロックを構築するため、ユニオン・ファイル・システムを使います。Docker は AUFS、btrfs、vfs、DeviceMapper を含む複数のユニオン・ファイル・システムの派生を利用できます。
+ユニオン・ファイル・システムは UnionFS というものであり、レイヤが作り出され、軽量かつ高速に処理が行われるファイルシステムのことです。
+Docker Engine は UnionFS を利用して、コンテナにおけるブロックを構築します。
+Docker Engine では AUFS、btrfs、vfs、DeviceMapper などの UnionFS 系のファイルシステムも利用できます。
 
 .. Container format
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -362,9 +362,10 @@ Dockerfile の内容を書き換えたことでイメージが再構築される
 
     $ docker run -i -t ubuntu /bin/bash
 
-.. When you run this command, the following happens (assuming you are using the default registry configuration):
+.. When you run this command, the following happens (assuming you are using
+   the default registry configuration):
 
-このコマンドを実行し、以下の処理が発生します（デフォルトのレジストリ設定を用いているものと想定）。
+このコマンドを実行すると、以下が発生します（レジストリから入手した際のデフォルトの設定を使用しているものとします）。
 
 ..    If you do not have the ubuntu image locally, Docker pulls it from your configured registry, as though you had run docker pull ubuntu manually.
     Docker creates a new container, as though you had run a docker create command manually.

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -367,14 +367,15 @@ Dockerfile の内容を書き換えたことでイメージが再構築される
 
 このコマンドを実行すると、以下が発生します（レジストリから入手した際のデフォルトの設定を使用しているものとします）。
 
-..    If you do not have the ubuntu image locally, Docker pulls it from your configured registry, as though you had run docker pull ubuntu manually.
-    Docker creates a new container, as though you had run a docker create command manually.
+.. 1.  If you do not have the `ubuntu` image locally, Docker pulls it from your
+       configured registry, as though you had run `docker pull ubuntu` manually.
+   Docker creates a new container, as though you had run a docker create command manually.
     Docker allocates a read-write filesystem to the container, as its final layer. This allows a running container to create or modify files and directories in its local filesystem.
     Docker creates a network interface to connect the container to the default network, since you did not specify any networking options. This includes assigning an IP address to the container. By default, containers can connect to external networks using the host machine’s network connection.
     Docker starts the container and executes /bin/bash. Because the container is run interactively and attached to your terminal (due to the -i and -t) flags, you can provide input using your keyboard and output is logged to your terminal.
     When you type exit to terminate the /bin/bash command, the container stops but is not removed. You can start it again or remove it.
 
-1. ``ubuntu`` イメージがローカルになければ、Docker は特定のレジストリからイメージを取得（pull）します。この操作は手動で ``docker pull ubuntu`` を実行するのと同じです。
+1. ``ubuntu`` イメージがローカルになければ、Docker は設定されているレジストリからイメージを取得します。この動作は手動で ``docker pull ubuntu`` を実行するのと同じです。
 2. Docker は新しいコンテナを作成します。こちらは手動で ``docker create`` コマンドを実行するのと同じです。
 3. 読み書き可能なファイルシステムを、Docker はコンテナに新しいレイヤとして割り当てます。
 4. Docker はネットワーク・インターフェースを作成し、ネットワークのオプション指定がなければ、コンテナをデフォルト・ネットワークに接続します。この時、コンテナに IP アドレスを割り当てます。ホストマシンのネットワークと接続するネットワークを使わなければ、コンテナはデフォルトで外部のネットワークと接続できません。

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -128,7 +128,7 @@ Docker の詳細については、 :ref:`docker-architecture` を参照してく
 
 .. _what-can-i-use-docker-for:
 
-何のために Docker を使うのですか？
+何のために Docker を使うのか？
 ========================================
 
 .. Fast, consistent delivery of your applications

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -374,14 +374,17 @@ Dockerfile の内容を書き換えたことでイメージが再構築される
    3.  Docker allocates a read-write filesystem to the container, as its final
        layer. This allows a running container to create or modify files and
        directories in its local filesystem.
-    Docker creates a network interface to connect the container to the default network, since you did not specify any networking options. This includes assigning an IP address to the container. By default, containers can connect to external networks using the host machine’s network connection.
+   4.  Docker creates a network interface to connect the container to the default
+       network, since you did not specify any networking options. This includes
+       assigning an IP address to the container. By default, containers can
+       connect to external networks using the host machine's network connection.
     Docker starts the container and executes /bin/bash. Because the container is run interactively and attached to your terminal (due to the -i and -t) flags, you can provide input using your keyboard and output is logged to your terminal.
     When you type exit to terminate the /bin/bash command, the container stops but is not removed. You can start it again or remove it.
 
 1. ``ubuntu`` イメージがローカルになければ、Docker は設定されているレジストリからイメージを取得します。この動作は手動で ``docker pull ubuntu`` を実行するのと同じです。
 2. Docker は新しいコンテナを生成します。これは手動で ``docker create`` コマンドを実行することと同じです。
 3. Docker はコンテナに対して読み書きが可能なファイルシステムを割り当てます。これが最終的にレイヤとなります。このことによりコンテナの稼動中に、ローカルなファイルシステム内でのファイルやディレクトリの生成や変更などが実現されます。
-4. Docker はネットワーク・インターフェースを作成し、ネットワークのオプション指定がなければ、コンテナをデフォルト・ネットワークに接続します。この時、コンテナに IP アドレスを割り当てます。ホストマシンのネットワークと接続するネットワークを使わなければ、コンテナはデフォルトで外部のネットワークと接続できません。
+4. Docker はネットワーク・インターフェースを生成し、コンテナをデフォルト・ネットワークに接続します。ここではネットワーク・オプションを指定していないものとしているためです。このときには、コンテナに対しての IP アドレスの割り当ても行われます。デフォルトでコンテナは、ホストマシンのネットワーク接続を利用して、外部ネットワークに接続します。
 5. Docker はコンテナを起動し、 ``/bin/bash`` を実行します。コンテナを双方向（interactive）かつターミナル（terminal）に接続する設定（ ``-i`` と ``-t`` のフラグによる）で実行しているため、キーボードを使っての入力や、出力をターミナルに表示できます。
 6. ``exit`` を入力すると、 ``/bin/bash`` コマンドは終了し、コンテナは停止状態となりますが、削除はされていません。コンテナを再起動するか、削除できます。
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -49,7 +49,7 @@ Docker プラットフォーム
    combination than if you were using virtual machines. You can even run Docker
    containers within host machines that are actually virtual machines!
 
-Docker はアプリケーションをパッケージ化して実行するために、ほぼ分離された環境となるコンテナというものを提供します。
+Docker はアプリケーションをパッケージ化して実行するために、ほぼ分離された環境 [#f1]_ となるコンテナというものを提供します。
 隔離してセキュリティを保つことから、実行するホスト上に複数のコンテナを同時に実行することができます。
 コンテナは非常に軽量なものとなります。
 なぜならハイパーバイザーを別途ロードする必要などなく、ホストマシンのカーネルを使って動作するからです。
@@ -61,13 +61,16 @@ Docker はアプリケーションをパッケージ化して実行するため�
 
 Docker が提供するのは、コンテナのライフサイクルを管理するツールとプラットフォームです。
 
-..    Develop your application and its supporting components using containers.
-    The container becomes the unit for distributing and testing your application.
-    When you’re ready, deploy your application into your production environment, as a container or an orchestrated service. This works the same whether your production environment is a local data center, a cloud provider, or a hybrid of the two.
+.. * Develop your application and its supporting components using containers.
+   * The container becomes the unit for distributing and testing your application.
+   * When you're ready, deploy your application into your production environment,
+     as a container or an orchestrated service. This works the same whether your
+     production environment is a local data center, a cloud provider, or a hybrid
+     of the two.
 
-* コンテナを用いたアプリケーション開発と、コンポーネント [#f2]_ をサポートします
-* コンテナはアプリケーションの配布またはテストの単位になります
-* アプリケーションの準備が整えば、コンテナまたはオーケストレートされたサービス [#f3]_ を通してアプリケーションをプロダクション環境にデプロイできます
+* コンテナを利用して、アプリケーションとそれをサポートするコンポーネント [#f2]_ を開発します。
+* コンテナは、アプリケーションの配布とテストを行う１つの単位となります。
+* 準備ができたら本番環境に向けてアプリケーションをデプロイします。デプロイの単位は、１つのコンテナか、あるいはオーケストレーション（orchestrated [#f3]_ ）された１つのサービスです。その本番環境があたかも手元のデータセンタ上であったり、クラウドプロバイダ上であったりするのと同様に動作します。
 
 .. rubric:: 訳者注
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -230,9 +230,11 @@ Docker クライアントとデーモンの間の通信には REST API が利用
 Docker デーモン
 --------------------
 
-.. The Docker daemon (dockerd) listens for Docker API requests and manages Docker objects such as images, containers, networks, and volumes. A daemon can also communicate with other daemons to manage Docker services.
+.. The Docker daemon (`dockerd`) listens for Docker API requests and manages Docker
+   objects such as images, containers, networks, and volumes. A daemon can also
+   communicate with other daemons to manage Docker services.
 
-Docker デーモン（ ``dockerd`` ）は Docker API リクエストを受け付け、イメージ、コンテナ、ネットワーク、ボリュームといった Docker オブジェクトを管理します。また、Docker サービスを管理するため、デーモンは他のデーモンと通信できます。
+Docker デーモン（ ``dockerd`` ）は Docker API リクエストを受け付け、イメージ、コンテナ、ネットワーク、ボリュームといった Docker オブジェクトを管理します。また、Docker サービスを管理するため、他のデーモンとも通信を行います。
 
 .. The Docker client
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -453,11 +453,11 @@ Docker Engine が取り扱う名前空間は、Linux 上で言えば以下のよ
     - **The `uts` namespace:** Isolating kernel and version identifiers. (UTS: Unix
    Timesharing System).
 
-* **pid 名前区間** ：プロセスの分離。（PID：プロセス ID）
-* **net 名前区間** ：ネットワーク・インターフェースの管理。（NET：ネットワーキング）
-* **ipc 名前区間** ：IPC リソースに対するアクセス管理。（IPC：InterProcess Communication、内部プロセスの通信）
-* **mnt 名前区間** ：ファイルシステムのマウント・ポイントの管理。（MNT：マウント）
-* **uts 名前区間** ：カーネルとバージョンの分離。（UTS：Unix  Timesharing System、Unix タイムシェアリング・システム）
+* **pid 名前空間** ：プロセスの分離。（PID：プロセス ID）
+* **net 名前空間** ：ネットワーク・インターフェースの管理。（NET：ネットワーキング）
+* **ipc 名前空間** ：IPC リソースに対するアクセス管理。（IPC：InterProcess Communication、内部プロセスの通信）
+* **mnt 名前空間** ：ファイルシステムのマウント・ポイントの管理。（MNT：マウント）
+* **uts 名前空間** ：カーネルとバージョンの分離。（UTS：Unix  Timesharing System、Unix タイムシェアリング・システム）
 
 .. ### Control groups
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -353,9 +353,10 @@ Dockerfile の内容を書き換えたことでイメージが再構築される
 
 **``docker run`` コマンドの例**
 
-.. The following command runs an ubuntu container, attaches interactively to your local command-line session, and runs /bin/bash.
+.. The following command runs an `ubuntu` container, attaches interactively to your
+   local command-line session, and runs `/bin/bash`.
 
-次のコンテナは ``ubuntu`` コンテナを実行し、ローカルのコマンドライン・セッションと双方向（インタラクティブ）に接続（アタッチ）し、 ``/bin/bash`` を実行します。
+次のコマンドは ``ubuntu`` コンテナを実行し、ローカルのコマンドライン処理のセッションを結びつけます。そして ``/bin/bash`` を実行します。
 
 .. code-block:: bash
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -272,9 +272,15 @@ Docker Hub と Docker Cloud は公開レジストリであり、誰でも利用�
 
 ``docker pull`` や ``docker run`` コマンドを使うと、設定されたレジストリから必要なイメージを取得します。 ``docker push`` コマンドを使えば、イメージを指定したレジストリに送信します。
 
-.. Docker store allows you to buy and sell Docker images or distribute them for free. For instance, you can buy a Docker image containing an application or service from a software vendor and use the image to deploy the application into your testing, staging, and production environments. You can upgrade the application by pulling the new version of the image and redeploying the containers.
+.. [Docker store](http://store.docker.com) allows you to buy and sell Docker images
+   or distribute them for free. For instance, you can buy a Docker image containing
+   an application or service from a software vendor and use the image to deploy
+   the application into your testing, staging, and production environments. You can
+   upgrade the application by pulling the new version of the image and redeploying
+   the containers.
 
-`Docker ストア <http://store.docker.com/>`_ で Docker イメージの売買や、自由な配布ができます。たとえば、ソフトウェア・ベンダのアプリケーションやサービスを含む Docker イメージの購入や、そのイメージを使ってアプリケーションをテスト、ステージング、プロダクション環境に展開（デプロイ）できます。アプリケーションを更新するには、イメージの新しいバージョンを取得し、コンテナの再展開によって可能です。
+`Docker ストア <http://store.docker.com/>`_ を利用すれば Docker イメージの売買や無償配布ができます。
+たとえば、ソフトウェア・ベンダが提供するアプリケーションやサービスを含んだ Docker イメージを購入し、そのイメージを使って、テスト、ステージング、本番の各環境にアプリケーションをデプロイすることができます。アプリケーションを更新するには、もう一度イメージの新バージョンを取得し、コンテナを再デプロイすれば実現できます。
 
 Docker オブジェクト
 --------------------

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -120,8 +120,9 @@ Docker オブジェクトとは、イメージ、コンテナー、ネットワ�
 
    Docker は、オープンソース Apache 2.0 ライセンスのもとで提供されています。
 
-Docker の詳細についれは、 :ref:`docker-architecture` をお読みください。
+.. For more details, see [Docker Architecture](#docker-architecture) below.
 
+Docker の詳細については、 :ref:`docker-architecture` を参照してください。
 
 .. What can I use Docker for?
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -167,7 +167,7 @@ Docker は開発のライフサイクルを効率化します。
 .. Responsive deployment and scaling
 .. _responsive-deployment-and-scaling:
 
-即応性のあるデプロイとスケーリング
+迅速なデプロイとスケーリング
 ----------------------------------------
 
 .. Docker’s container-based platform allows for highly portable workloads. Docker containers can run on a developer’s local laptop, on physical or virtual machines in a data center, on cloud providers, or in a mixture of environments.

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -507,13 +507,15 @@ Docker Engine では AUFS、btrfs、vfs、DeviceMapper などの UnionFS 系の�
 次のステップ
 ====================
 
-..    Read about installing Docker.
-    Get hands-on experience with the Getting started with Docker tutorial.
-    Check out examples and deep dive topics in the Docker Engine user guide.
+.. - Read about [installing Docker](installation/index.md#installation).
+   - Get hands-on experience with the [Getting started with Docker](getstarted/index.md)
+       tutorial.
+   - Check out examples and deep dive topics in the
+       [Docker Engine user guide](userguide/index.md).
 
-* :doc:`/engine/installation` を読む
-* :doc:`チュートリアル </get-started/index>` で手を動かす
-* :doc:`Docker Engine ユーザ・ガイド </engine/userguide/index>` で例や詳細トピックを確認
+* :doc:`/engine/installation` に進む。
+* :doc:`Docker を使い始める </get-started/index>` を試す。
+* 利用例を確認したり詳細なトピックを突き詰めたりするために :doc:`Docker Engine ユーザ・ガイド </engine/userguide/index>` を読む。
 
 
 .. seealso:: 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -22,9 +22,17 @@
 Docker 概要
 =======================================
 
-.. Docker is an open platform for developing, shipping, and running applications. Docker enables you to separate your applications from your infrastructure so you can deliver software quickly. With Docker, you can manage your infrastructure in the same ways you manage your applications. By taking advantage of Docker’s methodologies for shipping, testing, and deploying code quickly, you can significantly reduce the delay between writing code and running it in production.
+.. Docker is an open platform for developing, shipping, and running applications.
+   Docker enables you to separate your applications from your infrastructure so
+   you can deliver software quickly. With Docker, you can manage your infrastructure
+   in the same ways you manage your applications. By taking advantage of Docker's
+   methodologies for shipping, testing, and deploying code quickly, you can
+   significantly reduce the delay between writing code and running it in production.
 
-Docker はアプリケーションを開発（developing）・移動（shipping）・実行（running）するための、オープンなプラットフォームです。Docker はアプリケーションをインフラストラクチャ（訳者注；システムおよびネットワーク基盤）から切り離せるため、ソフトウェアを素早く配信できます。Docker であれば、皆さんがアプリケーションを管理するのと同じ手法で、インフラストラクチャを管理できます。移動、テスト、コードのデプロイが迅速に行えるのが Docker を扱う手法の利点です。そのため、コードの記述とプロダクションでの実行までの間の遅延を著しく減らします。
+Docker はアプリケーションの開発、導入、実行を行うためのオープンなプラットフォームです。
+Docker を使えば、アプリケーションをインフラストラクチャーから切り離すことができるため、ソフトウエアをすばやく提供することができます。
+Docker であれば、アプリケーションを管理する手法をそのまま、インフラストラクチャーの管理にも適用できます。
+Docker が採用する方法を最大限利用して、アプリケーションの導入、テスト、コードデプロイをすばやく行うことは、つまりコーディングと実稼動の合間を大きく軽減できることを意味します。
 
 .. The Docker platform
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -382,14 +382,15 @@ Dockerfile の内容を書き換えたことでイメージが再構築される
        is run interactively and attached to your terminal (due to the `-i` and `-t`)
        flags, you can provide input using your keyboard and output is logged to
        your terminal.
-    When you type exit to terminate the /bin/bash command, the container stops but is not removed. You can start it again or remove it.
+   6.  When you type `exit` to terminate the `/bin/bash` command, the container
+       stops but is not removed. You can start it again or remove it.
 
 1. ``ubuntu`` イメージがローカルになければ、Docker は設定されているレジストリからイメージを取得します。この動作は手動で ``docker pull ubuntu`` を実行するのと同じです。
 2. Docker は新しいコンテナを生成します。これは手動で ``docker create`` コマンドを実行することと同じです。
 3. Docker はコンテナに対して読み書きが可能なファイルシステムを割り当てます。これが最終的にレイヤとなります。このことによりコンテナの稼動中に、ローカルなファイルシステム内でのファイルやディレクトリの生成や変更などが実現されます。
 4. Docker はネットワーク・インターフェースを生成し、コンテナをデフォルト・ネットワークに接続します。ここではネットワーク・オプションを指定していないものとしているためです。このときには、コンテナに対しての IP アドレスの割り当ても行われます。デフォルトでコンテナは、ホストマシンのネットワーク接続を利用して、外部ネットワークに接続します。
 5. Docker はコンテナを起動し、 ``/bin/bash`` を実行します。（ ``-i`` と ``-t`` のフラグにより）対話的に、かつターミナル画面に接続するようにして実行しているため、手元のキーボードを使って入力することができ、ターミナル画面に出力が行われるようになります。
-6. ``exit`` を入力すると、 ``/bin/bash`` コマンドは終了し、コンテナは停止状態となりますが、削除はされていません。コンテナを再起動するか、削除できます。
+6. ``exit`` を入力すると、 ``/bin/bash`` コマンドは終了します。コンテナは停止状態となりますが、削除はされません。コンテナを再起動したり削除することもできます。
 
 サービス
 ^^^^^^^^^^

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -294,9 +294,17 @@ Docker の利用時は、イメージ、コンテナ、ネットワーク、ボ�
 イメージ
 ^^^^^^^^^^
 
-.. An image is a read-only template with instructions for creating a Docker container. Often, an image is based on another image, with some additional customization. For example, you may build an image which is based on the ubuntu image, but installs the Apache web server and your application, as well as the configuration details needed to make your application run.
+.. An _image_ is a read-only template with instructions for creating a Docker
+   container. Often, an image is _based on_ another image, with some additional
+   customization. For example, you may build an image which is based on the `ubuntu`
+   image, but installs the Apache web server and your application, as well as the
+   configuration details needed to make your application run.
 
-イメージ（ ``image`` ）とは、Docker コンテナを作成する命令が入った読み込み専用のテンプレートです。通常、イメージは、他のイメージを元（ベース）にして何らかのカスタマイズを追加したものです。例えば、 ``ubuntu`` イメージを元にして、Apache ウェブサーバやアプリケーションのインストールだけでなく、アプリケーションの実行に必要な設定詳細も含めたイメージを構築できます。
+イメージ（ ``image`` ）とは、Docker コンテナを作成する命令が入った読み込み専用のテンプレートです。
+通常イメージは、他のイメージをベースにしてそれをカスタマイズして利用します。
+たとえば ``ubuntu`` イメージをベースとするイメージを作ったとします。
+そこには Apache ウェブ・サーバや自開発したアプリケーションといったものをインストールするかもしれません。
+さらにアプリケーション実行に必要となる詳細な設定も加えることにもなるでしょう。
 
 .. You might create your own images or you might only use those created by others and published in a registry. To build your own image, you create a Dockerfile with a simple syntax for defining the steps needed to create the image and run it. Each instruction in a Dockerfile creates a layer in the image. When you change the Dockerfile and rebuild the image, only those layers which have changed are rebuilt. This is part of what makes images so lightweight, small, and fast, when compared to other virtualization technologies.
 

--- a/engine/docker-overview.rst
+++ b/engine/docker-overview.rst
@@ -395,9 +395,22 @@ Dockerfile の内容を書き換えたことでイメージが再構築される
 サービス
 ^^^^^^^^^^
 
-.. Services allow you to scale containers across multiple Docker daemons, which all work together as a swarm with multiple managers and workers. Each member of a swarm is a Docker daemon, and the daemons all communicate using the Docker API. A service allows you to define the desired state, such as the number of replicas of the service that must be available at any given time. By default, the service is load-balanced across all worker nodes. To the consumer, the Docker service appears to be a single application. Docker Engine supports swarm mode in Docker 1.12 and higher.
+.. Services allow you to scale containers across multiple Docker daemons, which
+   all work together as a _swarm_ with multiple _managers_ and _workers_. Each
+   member of a swarm is a Docker daemon, and the daemons all communicate using
+   the Docker API. A service allows you to define the desired state, such as the
+   number of replicas of the service that must be available at any given time.
+   By default, the service is load-balanced across all worker nodes. To
+   the consumer, the Docker service appears to be a single application. Docker
+   Engine supports swarm mode in Docker 1.12 and higher.
 
-サービス（services）とは、複数の Docker デーモンを横断してコンテナをスケールできます。複数の Docker デーモンは複数のマネージャ（ `manager` ）とワーカ（ `worker` ）が `swarm` （スウォーム、訳者注；Docker用語で複数の Docker デーモンで構成する「クラスタ」を意味）として協調動作します。swarm を構成するのは Docker デーモンであり、デーモンは全て Docker API を使って通信します。サービスは、サービスのレプリカ数など期待状態（desired state）を常に定義する必要があります。デフォルトでは、サービスは全てのワーカ・ノードを横断して負荷部産します。利用者からすると、 Docker サービスは１つのアプリケーションのように見えます。Docker 1.12 以上で Docker Engine は swarm mode をサポートしました。
+サービスは、複数の Docker デーモンにわたって、コンテナのスケール変更ができるようにします。
+複数のデーモンはスォームと呼ばれるものとして扱われ、複数のマネージャ、ワーカとともに動作します。
+そしてすべてのデーモンが Docker API を利用して通信します。
+サービスは必要となる状態を定義することが可能であり、たとえばサービスのレプリカ数を、指定した時間においてどれだけ作り出すかを定義できます。
+デフォルトでは、すべてのワーカ・ノードにわたって負荷分散が行われます。
+利用者からすると、Docker サービスは１つのアプリケーションとして見えます。
+Docker Engine がスウォームモードをサポートするのは Docker バージョン 1.12 またはそれ以上です。
 
 .. The underlying technology
 


### PR DESCRIPTION
訳修正案 /engine/docker_overview です。よろしくお願いします。

誤訳が相当数あります。このような形で進めて良いものかどうか疑問も抱いています。コメントをどうぞよろしくお願い致します。