### PR TITLE
訳修正案 /engine/reference/builder その２

### DIFF
--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1349,9 +1349,13 @@ ADD されるファイルやディレクトリの UID と GID は、すべて 0 
      名前によって判断されるわけではありません。
      たとえば、空のファイルの名前の末尾がたまたま ``.tar.gz`` となっていた場合、圧縮ファイルとして認識されないため、解凍に失敗したといったエラーメッセージは一切 **出ることはなく** 、このファイルはコピー先に向けて単純にコピーされるだけです。
 
-..    If <src> is any other kind of file, it is copied individually along with its metadata. In this case, if <dest> ends with a trailing slash /, it will be considered a directory and the contents of <src> will be written at <dest>/base(<src>).
+.. - If `<src>` is any other kind of file, it is copied individually along with
+     its metadata. In this case, if `<dest>` ends with a trailing slash `/`, it
+     will be considered a directory and the contents of `<src>` will be written
+     at `<dest>/base(<src>)`.
 
-* もし ``<ソース>`` がファイル以外であれば、個々のメタデータと一緒にコピーします。 ``<送信先>`` の末尾がスラッシュ ``/`` で終わる場合は、ディレクトリであるとみなし、 ``<ソース>`` の内容を ``<送信先>/base(<ソース>)`` に書き込みます。
+* ``<src>`` が上に示す以外のファイルであった場合、メタデータも含めて個々にコピーされます。
+  このとき ``<dest>`` が ``/`` で終わっていたらディレクトリとみなされるので、``<src>`` の内容は ``<dest>/base(<src>)`` に書き込まれることになります。
 
 ..    If multiple <src> resources are specified, either directly or due to the use of a wildcard, then <dest> must be a directory, and it must end with a slash /.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -886,9 +886,10 @@ CMD
 
 シェル形式または exec 形式を用いる場合、``CMD`` 命令は、イメージが起動されたときに実行するコマンドを指定します。
 
-.. If you use the shell form of the CMD, then the <command> will execute in /bin/sh -c:
+.. If you use the *shell* form of the `CMD`, then the `<command>` will execute in
+   `/bin/sh -c`:
 
-``CMD`` を *シェル* 形式で使えば、 ``<コマンド>`` は ``/bin/sh -c`` で実行されます。
+シェル形式を用いる場合、``<command>`` は ``/bin/sh -c`` の中で実行されます。
 
 .. code-block:: dockerfile
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1240,11 +1240,18 @@ ADD されるファイルやディレクトリの UID と GID は、すべて 0 
 リモートファイルの取得時に HTTP の ``Last-Modified`` ヘッダが含まれている場合は、ヘッダに書かれたタイムスタンプを利用して、コピー先ファイルの ``mtime`` を設定します。
 ただし ``ADD`` によって処理されるファイルが何であっても、ファイルが変更されたかどうか、そしてキャッシュを更新するべきかどうかは ``mtime`` によって判断されるわけではありません。
 
-..    Note: If you build by passing a Dockerfile through STDIN (docker build - < somefile), there is no build context, so the Dockerfile can only contain a URL based ADD instruction. You can also pass a compressed archive through STDIN: (docker build - < archive.tar.gz), the Dockerfile at the root of the archive and the rest of the archive will get used at the context of the build.
+.. > **Note**:
+   > If you build by passing a `Dockerfile` through STDIN (`docker
+   > build - < somefile`), there is no build context, so the `Dockerfile`
+   > can only contain a URL based `ADD` instruction. You can also pass a
+   > compressed archive through STDIN: (`docker build - < archive.tar.gz`),
+   > the `Dockerfile` at the root of the archive and the rest of the
+   > archive will be used as the context of the build.
 
 .. note::
 
-   ``Dockerfile`` を標準入力（ ``docker build - < 何らかのファイル`` ）を通して構築しようとしても。構築時のコンテントは存在しないため、 ``Dockerfile`` には URL を指定する ``ADD`` 命令のみ記述可能です。また、圧縮ファイルを標準入力（ ``docker build - < archive.tar.gz`` ）を通すことができ、アーカイブに含まれるルートに ``Dockerfile`` があれば、構築時のコンテクストとしてアーカイブが使われます。
+   ``Dockerfile`` を標準入力から生成する場合（ ``docker build - < somefile`` ）は、ビルド・コンテキストが存在していないことになるので、``ADD`` 命令には URL の指定しか利用できません。
+   また標準入力から圧縮アーカイブを入力する場合（ ``docker build - < archive.tar.gz`` ）は、そのアーカイブのルートにある ``Dockerfile`` と、アーカイブ内のファイルすべてが、ビルド時のコンテキストとなります。
 
 ..    Note: If your URL files are protected using authentication, you will need to use RUN wget, RUN curl or use another tool from within the container as the ADD instruction does not support authentication.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -978,7 +978,7 @@ LABEL
 
 .. The above can also be written as:
 
-上記の例は、次のようにも書き換えられます。
+上記の例は、以下のように書くこともできます。
 
 .. code-block:: dockerfile
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1199,9 +1199,11 @@ ADD には 2 つの書式があります。
    ADD hom* /mydir/        # "hom" で始まる全てのファイルを追加
    ADD hom?.txt /mydir/    # ? は１文字だけ一致します。例： "home.txt"
 
-.. The <dest> is an absolute path, or a path relative to WORKDIR, into which the source will be copied inside the destination container.
+.. The `<dest>` is an absolute path, or a path relative to `WORKDIR`, into which
+   the source will be copied inside the destination container.
 
-``<送信先>`` は絶対パスです。あるいは、パスは ``WORKDIR`` からの相対パスです。ソースにあるものが、対象となる送信先コンテナの中にコピーされます。
+``<dest>`` は絶対パスか、あるいは ``WORKDIR`` からの相対パスにより指定します。
+対象としているコンテナ内において、そのパスに対してソースがコピーされます。
 
 .. code-block:: dockerfile
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -961,9 +961,16 @@ LABEL
    LABEL description="This text illustrates \
    that label-values can span multiple lines."
 
-.. An image can have more than one label. To specify multiple labels, Docker recommends combining labels into a single LABEL instruction where possible. Each LABEL instruction produces a new layer which can result in an inefficient image if you use many labels. This example results in a single image layer.
+.. An image can have more than one label. To specify multiple labels,
+   Docker recommends combining labels into a single `LABEL` instruction where
+   possible. Each `LABEL` instruction produces a new layer which can result in an
+   inefficient image if you use many labels. This example results in a single image
+   layer.
 
-イメージは複数のラベルを持てます。複数のラベルを指定したら、 Docker は可能であれば１つの ``LABEL`` にすることをお勧めします。各 ``LABEL`` 命令は新しいレイヤを準備しますが、多くのラベルを使えば、それだけレイヤを使います。次の例は１つのイメージ・レイヤを使うものです。
+イメージには複数のラベルを含めることができます。
+複数のラベルを指定する場合、可能であれば ``LABEL`` 命令の記述を 1 行とすることをお勧めします。
+``LABEL`` 命令 1 つからは新しいレイヤが生成されますが、多数のラベルを利用すると、非効率なイメージがビルドされてしまいます。
+以下の例は、ただ 1 つのイメージ・レイヤを作るものです。
 
 .. code-block:: dockerfile
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1502,9 +1502,10 @@ COPY は２つの形式があります。
 
 * 複数の ``<src>`` が直接指定された場合、あるいはワイルドカードを用いて指定された場合、``<dest>`` はディレクトリとする必要があり、末尾には ``/`` をつけなければなりません。
 
-..    If <dest> does not end with a trailing slash, it will be considered a regular file and the contents of <src> will be written at <dest>.
+.. - If `<dest>` does not end with a trailing slash, it will be considered a
+     regular file and the contents of `<src>` will be written at `<dest>`.
 
-* もし ``<送信先>`` の末尾がスラッシュで終わらなければ、通常のファイルとみなされ、 ``<ソース>`` の内容は ``<送信先>`` として書き込まれます。
+* ``<dest>`` の末尾にスラッシュがなかった場合、通常のファイルとみなされるため、``<src>`` の内容が ``<dest>`` に書き込まれます。
 
 ..    If <dest> doesn’t exist, it is created along with all missing directories in its path.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1133,9 +1133,12 @@ ENV
    ENV myDog Rex The Dog
    ENV myCat fluffy
 
-.. will yield the same net results in the final container, but the first form is preferred because it produces a single cache layer.
+.. will yield the same net results in the final image, but the first form
+   is preferred because it produces a single cache layer.
 
-この例では、どちらも最終的に同じ結果をコンテナにもたらしますが、私たちが推奨するのは前者です。理由は前者であれば単一のキャッシュ・レイヤしか使わないからです。
+上の 2 つは最終的に同じ結果をイメージに書き入れます。
+ただし 1 つめの書式が望ましいものです。
+1 つめは単一のキャッシュ・レイヤしか生成しないからです。
 
 .. The environment variables set using ENV will persist when a container is run from the resulting image. You can view the values using docker inspect, and change them using docker run --env <key>=<value>.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -835,9 +835,14 @@ CMD
 ``Dockerfile`` では ``CMD`` 命令を 1 つしか記述できません。
 仮に複数の ``CMD`` を記述しても、最後の ``CMD`` 命令しか処理されません。
 
-.. The main purpose of a CMD is to provide defaults for an executing container. These defaults can include an executable, or they can omit the executable, in which case you must specify an ENTRYPOINT instruction as well.
+.. **The main purpose of a `CMD` is to provide defaults for an executing
+   container.** These defaults can include an executable, or they can omit
+   the executable, in which case you must specify an `ENTRYPOINT`
+   instruction as well.
 
-``CMD`` の主な目的は、 **コンテナ実行時のデフォルトを提供します** 。 デフォルトには、実行可能なコマンドが含まれているか、あるいは省略されるかもしれません。省略時は ``ENTRYPOINT`` 命令で同様に指定する必要があります。
+``CMD`` 命令の主目的は、**コンテナの実行時のデフォルト処理を設定することです。**
+この処理設定においては、実行モジュールを含める場合と、実行モジュールを省略する場合があります。
+省略する場合は ``ENTRYPOINT`` 命令を合わせて指定する必要があります。
 
 ..     Note: If CMD is used to provide default arguments for the ENTRYPOINT instruction, both the CMD and ENTRYPOINT instructions should be specified with the JSON array format.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -986,9 +986,12 @@ LABEL
          multi.label2="value2" \
          other="value3"
 
-.. Labels are additive including LABELs in FROM images. If Docker encounters a label/key that already exists, the new value overrides any previous labels with identical keys.
+.. Labels are additive including `LABEL`s in `FROM` images. If Docker
+   encounters a label/key that already exists, the new value overrides any previous
+   labels with identical keys.
 
-ラベルには、``FROM`` イメージが使う ``LABEL`` も含まれています。ラベルのキーが既に存在している時、Docker は特定のキーを持つラベルの値を上書きします。
+ラベルには ``FROM`` に指定されたイメージ内の ``LABEL`` 命令も含まれます。
+ラベルのキーが既に存在していた場合、そのキーに対応する古い値は、新しい値によって上書きされます。
 
 .. To view an image’s labels, use the docker inspect command.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1400,9 +1400,12 @@ COPY は２つの形式があります。
 ``<src>`` には複数のソースを指定することが可能です。
 ソースとしてファイルあるいはディレクトリが指定されている場合、そのパスは生成されたソース・ディレクトリ（ビルド・コンテキスト）からの相対パスでなければなりません。
 
-.. Each <src> may contain wildcards and matching will be done using Go’s filepath.Match rules. For example:
+.. Each `<src>` may contain wildcards and matching will be done using Go's
+   [filepath.Match](http://golang.org/pkg/path/filepath#Match) rules. For example:
 
-それぞれの ``<ソース>`` にはワイルドカードと Go 言語の `filepath.Match <http://golang.org/pkg/path/filepath#Match>`_ ルールに一致するパターンが使えます。例えば、次のような記述です。
+``<src>`` にはワイルドカードを含めることができます。
+その場合、マッチング処理は Go 言語の `filepath.Match <http://golang.org/pkg/path/filepath#Match>`_ ルールに従って行われます。
+記述例は以下のとおりです。
 
 .. code-block:: dockerfile
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1140,9 +1140,12 @@ ENV
 ただし 1 つめの書式が望ましいものです。
 1 つめは単一のキャッシュ・レイヤしか生成しないからです。
 
-.. The environment variables set using ENV will persist when a container is run from the resulting image. You can view the values using docker inspect, and change them using docker run --env <key>=<value>.
+.. The environment variables set using `ENV` will persist when a container is run
+   from the resulting image. You can view the values using `docker inspect`, and
+   change them using `docker run --env <key>=<value>`.
 
-環境変数の設定に ``ENV`` を使えば、作成したイメージを使ってコンテナを実行しても有効です。どのような値が設定されているかは ``docker inspect`` で確認でき、変更するには ``docker run --env <key>=<value>`` を使います。
+``ENV`` を用いて設定された環境変数は、そのイメージから実行されたコンテナであれば維持されます。
+環境変数の参照は ``docker inspect`` を用い、値の変更は ``docker run --env <key>=<value>`` により行うことができます。
 
 ..    Note: Environment persistence can cause unexpected side effects. For example, setting ENV DEBIAN_FRONTEND noninteractive may confuse apt-get users on a Debian-based image. To set a value for a single command, use RUN <key>=<value> <command>.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1357,9 +1357,11 @@ ADD されるファイルやディレクトリの UID と GID は、すべて 0 
 * ``<src>`` が上に示す以外のファイルであった場合、メタデータも含めて個々にコピーされます。
   このとき ``<dest>`` が ``/`` で終わっていたらディレクトリとみなされるので、``<src>`` の内容は ``<dest>/base(<src>)`` に書き込まれることになります。
 
-..    If multiple <src> resources are specified, either directly or due to the use of a wildcard, then <dest> must be a directory, and it must end with a slash /.
+.. - If multiple `<src>` resources are specified, either directly or due to the
+     use of a wildcard, then `<dest>` must be a directory, and it must end with
+     a slash `/`.
 
-* もし複数の ``<ソース>`` リソースが指定された場合や、ディレクトリやワイルドカードを使った場合、 ``<送信先>`` は必ずディレクトリになり、最後はスラッシュ ``/`` にしなければいけません。
+* 複数の ``<src>`` が直接指定された場合、あるいはワイルドカードを用いて指定された場合、``<dest>`` はディレクトリとする必要があり、末尾には ``/`` をつけなければなりません。
 
 ..    If <dest> does not end with a trailing slash, it will be considered a regular file and the contents of <src> will be written at <dest>.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -829,9 +829,11 @@ CMD
 * ``CMD ["param1","param2"]`` ( ``ENTRYPOINT`` のデフォルト・パラメータとして)
 * ``CMD command param1 param2`` (シェル形式)
 
-.. There can only be one CMD instruction in a Dockerfile. If you list more than one CMD then only the last CMD will take effect.
+.. There can only be one `CMD` instruction in a `Dockerfile`. If you list more than one `CMD`
+   then only the last `CMD` will take effect.
 
-``Dockerfile`` で ``CMD`` 命令を一度だけ指定できます。複数の ``CMD`` がある場合、最も後ろの ``CMD`` のみ有効です。
+``Dockerfile`` では ``CMD`` 命令を 1 つしか記述できません。
+仮に複数の ``CMD`` を記述しても、最後の ``CMD`` 命令しか処理されません。
 
 .. The main purpose of a CMD is to provide defaults for an executing container. These defaults can include an executable, or they can omit the executable, in which case you must specify an ENTRYPOINT instruction as well.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1253,11 +1253,15 @@ ADD されるファイルやディレクトリの UID と GID は、すべて 0 
    ``Dockerfile`` を標準入力から生成する場合（ ``docker build - < somefile`` ）は、ビルド・コンテキストが存在していないことになるので、``ADD`` 命令には URL の指定しか利用できません。
    また標準入力から圧縮アーカイブを入力する場合（ ``docker build - < archive.tar.gz`` ）は、そのアーカイブのルートにある ``Dockerfile`` と、アーカイブ内のファイルすべてが、ビルド時のコンテキストとなります。
 
-..    Note: If your URL files are protected using authentication, you will need to use RUN wget, RUN curl or use another tool from within the container as the ADD instruction does not support authentication.
+.. > **Note**:
+   > If your URL files are protected using authentication, you
+   > will need to use `RUN wget`, `RUN curl` or use another tool from
+   > within the container as the `ADD` instruction does not support
+   > authentication.
 
 .. note::
 
-   URL で指定したファイルに認証がかかっている場合は、 ``RUN wget`` や ``RUN curl`` や他のツールを使う必要があります。これは ``ADD`` 命令が認証機能をサポートしていないからです。
+   URL ファイルが認証によって保護されている場合は、``RUN wget`` や ``RUN curl`` あるいは同様のツールをコンテナ内から利用する必要があります。``ADD`` 命令は認証処理をサポートしていません。
 
 ..    Note: The first encountered ADD instruction will invalidate the cache for all following instructions from the Dockerfile if the contents of <src> have changed. This includes invalidating the cache for RUN instructions. See the Dockerfile Best Practices guide for more information.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1310,11 +1310,13 @@ ADD されるファイルやディレクトリの UID と GID は、すべて 0 
 
 * ``<ソース>`` がディレクトリの場合、ディレクトリの内容の全てをコピーします。これにはファイルシステムのメタデータを含みます。
 
-..    Note: The directory itself is not copied, just its contents.
+  .. > **Note**:
+     > The directory itself is not copied, just its contents.
 
-.. note::
+  .. note::
 
-   ディレクトリ自身はコピーされません。ディレクトリは単なるコンテントの入れ物です。
+      ディレクトリそのものはコピーされません。
+      コピーされるのはその中身です。
 
 ..    If <src> is a local tar archive in a recognized compression format (identity, gzip, bzip2 or xz) then it is unpacked as a directory. Resources from remote URLs are not decompressed. When a directory is copied or unpacked, it has the same behavior as tar -x: the result is the union of:
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1084,9 +1084,14 @@ ENV
    ENV <key> <value>
    ENV <key>=<value> ...
 
-.. The ENV instruction sets the environment variable <key> to the value <value>. This value will be in the environment of all “descendant” Dockerfile commands and can be replaced inline in many as well.
+.. The `ENV` instruction sets the environment variable `<key>` to the value
+   `<value>`. This value will be in the environment of all "descendant"
+   `Dockerfile` commands and can be [replaced inline](#environment-replacement) in
+   many as well.
 
-``ENV`` 命令は、環境変数 ``<key>`` と 値 ``<value>`` のセットです。値は ``Dockerfile`` から派生する全てのコマンド環境で利用でき、 :ref:`インラインで置き換え <environment-replacement>` も可能です。
+``ENV`` 命令は、環境変数 ``<key>`` に ``<value>`` という値を設定します。
+``Dockerfile`` 内の後続命令の環境において、環境変数の値は維持されます。
+また、いろいろと :ref:`インラインにて変更 <environment-replacement>` することもできます。
 
 .. The ENV instruction has two forms. The first form, ENV <key> <value>, will set a single variable to a value. The entire string after the first space will be treated as the <value> - including characters such as spaces and quotes.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1440,7 +1440,7 @@ COPY は２つの形式があります。
 
 .. All new files and directories are created with a UID and GID of 0.
 
-追加される新しいファイルやディレクトリは、全て UID と GID が 0 として作成されます。
+コピーされるファイルやディレクトリの UID と GID は、すべて 0 として生成されます。
 
 ..    Note: If you build using STDIN (docker build - < somefile), there is no build context, so COPY can’t be used.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1423,6 +1423,21 @@ COPY は２つの形式があります。
    COPY test relativeDir/   # "test" を `WORKDIR`/relativeDir/ （相対ディレクトリ）に追加
    COPY test /absoluteDir/   # "test" を /absoluteDir/ （絶対ディレクトリ）に追加
 
+.. When copying files or directories that contain special characters (such as `[`
+   and `]`), you need to escape those paths following the Golang rules to prevent
+   them from being treated as a matching pattern. For example, to copy a file
+   named `arr[0].txt`, use the following;
+
+ファイルやディレクトリを追加する際に、その名前の中に（ ``[`` や ``]`` のような）特殊な文字が含まれている場合は、Go 言語のルールに従ってパス名をエスケープする必要があります。
+これはパターン・マッチングとして扱われないようにするものです。
+たとえば ``arr[0].txt`` というファイルを追加する場合は、以下のようにします。
+
+   .. COPY arr[[]0].txt /mydir/    # copy a file named "arr[0].txt" to /mydir/
+
+.. code-block:: dockerfile
+
+   COPY arr[[]0].txt /mydir/    # "arr[0].txt" というファイルを /mydir/ へコピー
+
 .. All new files and directories are created with a UID and GID of 0.
 
 追加される新しいファイルやディレクトリは、全て UID と GID が 0 として作成されます。

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -808,9 +808,9 @@ exec 形式は、シェル文字列が置換されないようにします。
   aufs の最新バージョンを利用するシステム（つまりマウントオプション ``dirperm1`` を設定可能なシステム）の場合、docker はレイヤーに対して ``dirperm1`` オプションをつけてマウントすることで、この問題を自動的に解消するように試みます。
   ``dirperm1`` オプションに関する詳細は ``aufs`` の `man ページ <https://github.com/sfjro/aufs3-linux/tree/aufs3.18/Documentation/filesystems/aufs>`_ を参照してください。
 
-.. If your system doesn’t have support for dirperm1, the issue describes a workaround.
+  .. If your system doesn't have support for `dirperm1`, the issue describes a workaround.
 
-システムが ``dirperm1`` をサポートしていない場合は、issue に回避方法があります。
+  ``dirperm1`` をサポートしていないシステムの場合は、issue に示される回避方法を参照してください。
 
 .. _cmd:
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1166,7 +1166,7 @@ ADD
 
 .. ADD has two forms:
 
-Add は２つの形式があります。
+ADD には 2 つの書式があります。
 
 ..    ADD <src>... <dest>
     ADD ["<src>",... "<dest>"] (this form is required for paths containing whitespace)

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1480,11 +1480,13 @@ COPY は２つの形式があります。
 
 * ``<ソース>`` がディレクトリの場合、ディレクトリ内容の全てをコピーします。これにはファイルシステムのメタデータを含みます。
 
-..    Note: The directory itself is not copied, just its contents.
+  .. > **Note**:
+     > The directory itself is not copied, just its contents.
 
-.. note::
+  .. note::
 
-   ディレクトリ自身はコピーしません。ディレクトリは単なるコンテントの入れ物です。
+     ディレクトリそのものはコピーされません。
+     コピーされるのはその中身です。
 
 ..     If <src> is any other kind of file, it is copied individually along with its metadata. In this case, if <dest> ends with a trailing slash /, it will be considered a directory and the contents of <src> will be written at <dest>/base(<src>).
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1288,9 +1288,10 @@ ADD されるファイルやディレクトリの UID と GID は、すべて 0 
 * ``<src>`` のパス指定は、ビルド **コンテキスト** 内でなければならないため、たとえば ``ADD ../something /something`` といったことはできません。
   ``docker build`` の最初の処理ステップでは、コンテキスト・ディレクトリ（およびそのサブディレクトリ）を Docker デーモンに送信するところから始まるためです。
 
-..    If <src> is a URL and <dest> does not end with a trailing slash, then a file is downloaded from the URL and copied to <dest>.
+.. - If `<src>` is a URL and `<dest>` does not end with a trailing slash, then a
+     file is downloaded from the URL and copied to `<dest>`.
 
-* ``<ソース>`` が URL であり、 ``<送信先>`` の末尾にスラッシュが無い場合、URL からファイルをダウンロードし、 ``<送信先>`` にコピーします。
+* ``<src>`` が URL 指定であって ``<dest>`` の最後にスラッシュが指定されていない場合、そのファイルを URL よりダウンロードして ``<dest>`` にコピーします。
 
 ..    If <src> is a URL and <dest> does end with a trailing slash, then the filename is inferred from the URL and the file is downloaded to <dest>/<filename>. For instance, ADD http://example.com/foobar / would create the file /foobar. The URL must have a nontrivial path so that an appropriate filename can be discovered in this case (http://example.com will not work).
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1363,9 +1363,10 @@ ADD されるファイルやディレクトリの UID と GID は、すべて 0 
 
 * 複数の ``<src>`` が直接指定された場合、あるいはワイルドカードを用いて指定された場合、``<dest>`` はディレクトリとする必要があり、末尾には ``/`` をつけなければなりません。
 
-..    If <dest> does not end with a trailing slash, it will be considered a regular file and the contents of <src> will be written at <dest>.
+.. - If `<dest>` does not end with a trailing slash, it will be considered a
+     regular file and the contents of `<src>` will be written at `<dest>`.
 
-* もし ``<送信先>`` の末尾がスラッシュで終わらなければ、通常のファイルとみなされ、 ``<ソース>`` の内容は ``<送信先>`` として書き込まれます。
+* ``<dest>`` の末尾にスラッシュがなかった場合、通常のファイルとみなされるため、``<src>`` の内容は ``<dest>`` に書き込まれることになります。
 
 ..    If <dest> doesn’t exist, it is created along with all missing directories in its path.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1382,11 +1382,12 @@ COPY
 
 COPY は２つの形式があります。
 
-..    COPY <src>... <dest>
-    COPY ["<src>",... "<dest>"] (this form is required for paths containing whitespace)
+.. - `COPY <src>... <dest>`
+   - `COPY ["<src>",... "<dest>"]` (this form is required for paths containing
+   whitespace)
 
-* ``COPY <ソース>... <送信先>``
-* ``COPY ["<ソース>",... "<送信先>"]`` （この形式はパスに空白スペースを使う場合に必要）
+* ``COPY <src>... <dest>``
+* ``COPY ["<src>",... "<dest>"]`` （パスにホワイトスペースを含む場合にこの書式が必要）
 
 .. The COPY instruction copies new files or directories from <src> and adds them to the filesystem of the container at the path <dest>.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1147,11 +1147,17 @@ ENV
 ``ENV`` を用いて設定された環境変数は、そのイメージから実行されたコンテナであれば維持されます。
 環境変数の参照は ``docker inspect`` を用い、値の変更は ``docker run --env <key>=<value>`` により行うことができます。
 
-..    Note: Environment persistence can cause unexpected side effects. For example, setting ENV DEBIAN_FRONTEND noninteractive may confuse apt-get users on a Debian-based image. To set a value for a single command, use RUN <key>=<value> <command>.
+.. > **Note**:
+   > Environment persistence can cause unexpected side effects. For example,
+   > setting `ENV DEBIAN_FRONTEND noninteractive` may confuse apt-get
+   > users on a Debian-based image. To set a value for a single command, use
+   > `RUN <key>=<value> <command>`.
 
 .. note::
 
-   環境変数の一貫性は予期しない影響を与える場合があります。例えば、 ``ENV DEBIAN_FRONTEND noninteractive`` が設定されていると、Debian ベースのイメージで apt-get の利用者が混乱するかもしれません。１つのコマンドだけで値を設定するには、 ``RUN <key>=<value> <コマンド>`` を使います。
+   環境変数が維持されると、思わぬ副作用を引き起こすことがあります。
+   たとえば ``ENV DEBIAN_FRONTEND noninteractive`` という設定を行なっていると、Debian ベースのイメージにおいて apt-get を使う際には混乱を起こすかもしれません。
+   1 つのコマンドには 1 つの値のみを設定するには ``RUN <key>=<value> <command>`` を実行します。
 
 .. _add:
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1263,11 +1263,18 @@ ADD されるファイルやディレクトリの UID と GID は、すべて 0 
 
    URL ファイルが認証によって保護されている場合は、``RUN wget`` や ``RUN curl`` あるいは同様のツールをコンテナ内から利用する必要があります。``ADD`` 命令は認証処理をサポートしていません。
 
-..    Note: The first encountered ADD instruction will invalidate the cache for all following instructions from the Dockerfile if the contents of <src> have changed. This includes invalidating the cache for RUN instructions. See the Dockerfile Best Practices guide for more information.
+.. > **Note**:
+   > The first encountered `ADD` instruction will invalidate the cache for all
+   > following instructions from the Dockerfile if the contents of `<src>` have
+   > changed. This includes invalidating the cache for `RUN` instructions.
+   > See the [`Dockerfile` Best Practices
+   guide](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache) for more information.
 
 .. note::
 
-   ``ADD`` 命令の処理時、まず ``<ソース>`` に含まれる内容が変更されていれば、以降の ``Dockerfile`` に書かれている命令のキャッシュを全て無効化します。これは ``RUN`` 命令のキャッシュ無効化も含まれます。より詳細な情報については ``Dockerfile`` の :ref:`ベスト・プラクティス・ガイド <build-cache>` をご覧ください。
+   ``ADD`` 命令の ``<src>`` の内容が変更されていた場合、その ``ADD`` 命令以降に続く命令のキャッシュはすべて無効化されます。
+   そこには ``RUN`` 命令に対するキャッシュの無効化も含まれます。
+   詳しくは ``Dockerfile`` の :ref:`ベスト・プラクティス・ガイド <build-cache>` を参照してください。
 
 .. ADD obeys the following rules:
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1227,7 +1227,7 @@ ADD には 2 つの書式があります。
 
 .. All new files and directories are created with a UID and GID of 0.
 
-追加される新しいファイルやディレクトリは、全て UID と GID が 0 として作成されます。
+ADD されるファイルやディレクトリの UID と GID は、すべて 0 として生成されます。
 
 .. In the case where <src> is a remote file URL, the destination will have permissions of 600. If the remote file being retrieved has an HTTP Last-Modified header, the timestamp from that header will be used to set the mtime on the destination file. However, like any other file processed during an ADD, mtime will not be included in the determination of whether or not the file has changed and the cache should be updated.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1210,6 +1210,21 @@ ADD には 2 つの書式があります。
    ADD test relativeDir/          # "test" を `WORKDIR`/relativeDir/ （相対ディレクトリ）に追加
    ADD test /absoluteDir/          # "test" を /absoluteDir/ （絶対ディレクトリ）に追加
 
+.. When adding files or directories that contain special characters (such as `[`
+   and `]`), you need to escape those paths following the Golang rules to prevent
+   them from being treated as a matching pattern. For example, to add a file
+   named `arr[0].txt`, use the following;
+
+ファイルやディレクトリを追加する際に、その名前の中に（ ``[`` や ``]`` のような）特殊な文字が含まれている場合は、Go 言語のルールに従ってパス名をエスケープする必要があります。
+これはパターン・マッチングとして扱われないようにするものです。
+たとえば ``arr[0].txt`` というファイルを追加する場合は、以下のようにします。
+
+   ..  ADD arr[[]0].txt /mydir/    # copy a file named "arr[0].txt" to /mydir/
+
+.. code-block:: dockerfile
+
+   ADD arr[[]0].txt /mydir/    # "arr[0].txt" というファイルを /mydir/ へコピー
+
 .. All new files and directories are created with a UID and GID of 0.
 
 追加される新しいファイルやディレクトリは、全て UID と GID が 0 として作成されます。

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -896,9 +896,14 @@ CMD
    FROM ubuntu
    CMD echo "This is a test." | wc -
 
-.. If you want to run your <command> without a shell then you must express the command as a JSON array and give the full path to the executable. This array form is the preferred format of CMD. Any additional parameters must be individually expressed as strings in the array:
+.. If you want to **run your** `<command>` **without a shell** then you must
+   express the command as a JSON array and give the full path to the executable.
+   **This array form is the preferred format of `CMD`.** Any additional parameters
+   must be individually expressed as strings in the array:
 
-**<コマンド>をシェルを使わずに実行** したい場合、コマンドを JSON 配列で記述し、実行可能なフルパスで指定する必要があります。 **配列の形式が CMD では望ましい形式です** 。あらゆる追加パラメータは個々の配列の文字列として指定する必要があります。
+``<command>`` **をシェル実行することなく実行** したい場合は、そのコマンドを JSON 配列として表現し、またそのコマンドの実行モジュールへのフルパスを指定しなければなりません。
+**この配列書式は** ``CMD`` **において推奨される記述です。**
+パラメータを追加する必要がある場合は、配列内にて文字列として記述します。
 
 .. code-block:: dockerfile
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -821,13 +821,13 @@ CMD
 
 ``CMD`` には３つの形式があります。
 
-..    CMD ["executable","param1","param2"] (exec form, this is the preferred form)
-    CMD ["param1","param2"] (as default parameters to ENTRYPOINT)
-    CMD command param1 param2 (shell form)
+.. - `CMD ["executable","param1","param2"]` (*exec* form, this is the preferred form)
+   - `CMD ["param1","param2"]` (as *default parameters to ENTRYPOINT*)
+   - `CMD command param1 param2` (*shell* form)
 
-* ``CMD ["実行バイナリ", "パラメータ１", "パラメータ２"]`` （ *exec* 形式、推奨する形式）
-* ``CMD ["パラメータ１", "パラメータ２"]`` （ *ENTRYPOINT* のデフォルト・パラメータ）
-* ``CMD <コマンド>`` （シェル形式）
+* ``CMD ["executable","param1","param2"]`` (exec 形式、この形式が推奨される)
+* ``CMD ["param1","param2"]`` ( ``ENTRYPOINT`` のデフォルト・パラメータとして)
+* ``CMD command param1 param2`` (シェル形式)
 
 .. There can only be one CMD instruction in a Dockerfile. If you list more than one CMD then only the last CMD will take effect.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1488,9 +1488,13 @@ COPY は２つの形式があります。
      ディレクトリそのものはコピーされません。
      コピーされるのはその中身です。
 
-..     If <src> is any other kind of file, it is copied individually along with its metadata. In this case, if <dest> ends with a trailing slash /, it will be considered a directory and the contents of <src> will be written at <dest>/base(<src>).
+.. - If `<src>` is any other kind of file, it is copied individually along with
+     its metadata. In this case, if `<dest>` ends with a trailing slash `/`, it
+     will be considered a directory and the contents of `<src>` will be written
+     at `<dest>/base(<src>)`.
 
-* もし ``<ソース>`` がファイル以外であれば、個々のメタデータと一緒にコピーします。 ``<送信先>`` の末尾がスラッシュ ``/`` で終わる場合は、ディレクトリであるとみなし、 ``<ソース>`` の内容を ``<送信先>/base(<ソース>)`` に書き込みます。
+* ``<src>`` が上に示す以外のファイルであった場合、メタデータも含めて個々にコピーされます。
+  このとき ``<dest>`` が ``/`` で終わっていたらディレクトリとみなされるので、``<src>`` の内容は ``<dest>/base(<src>)`` に書き込まれることになります。
 
 ..    If multiple <src> resources are specified, either directly or due to the use of a wildcard, then <dest> must be a directory, and it must end with a slash /.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1412,9 +1412,11 @@ COPY は２つの形式があります。
    COPY hom* /mydir/        # "hom" で始まる全てのファイルを追加
    COPY hom?.txt /mydir/    # ? は１文字だけ一致します。例： "home.txt"
 
-.. The <dest> is an absolute path, or a path relative to WORKDIR, into which the source will be copied inside the destination container.
+.. The `<dest>` is an absolute path, or a path relative to `WORKDIR`, into which
+   the source will be copied inside the destination container.
 
-``<送信先>`` は絶対パスです。あるいは、パスは ``WORKDIR`` からの相対パスです。ソースにあるものが、対象となる送信先コンテナの中にコピーされます。
+``<dest>`` は絶対パスか、あるいは ``WORKDIR`` からの相対パスにより指定します。
+対象としているコンテナ内において、そのパスに対してソースがコピーされます。
 
 .. code-block:: dockerfile
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1280,9 +1280,13 @@ ADD されるファイルやディレクトリの UID と GID は、すべて 0 
 
 ``ADD`` は以下のルールに従います。
 
-..    The <src> path must be inside the context of the build; you cannot ADD ../something /something, because the first step of a docker build is to send the context directory (and subdirectories) to the docker daemon.
+.. - The `<src>` path must be inside the *context* of the build;
+     you cannot `ADD ../something /something`, because the first step of a
+     `docker build` is to send the context directory (and subdirectories) to the
+     docker daemon.
 
-* ``<ソース>`` パスは、構築時の *コンテント* 内にある必要があります。そのため、 ``ADD ../something /something`` の指定はできません。 ``docker build`` の最初のステップで、コンテクストのディレクトリ（と、サブディレクトリ）を docker デーモンに送るためです。
+* ``<src>`` のパス指定は、ビルド **コンテキスト** 内でなければならないため、たとえば ``ADD ../something /something`` といったことはできません。
+  ``docker build`` の最初の処理ステップでは、コンテキスト・ディレクトリ（およびそのサブディレクトリ）を Docker デーモンに送信するところから始まるためです。
 
 ..    If <src> is a URL and <dest> does not end with a trailing slash, then a file is downloaded from the URL and copied to <dest>.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -922,11 +922,17 @@ CMD
 
 ``docker run`` において引数を指定することで、``CMD`` 命令に指定されたデフォルトを上書きすることができます。
 
-..    Note: don’t confuse RUN with CMD. RUN actually runs a command and commits the result; CMD does not execute anything at build time, but specifies the intended command for the image.
+.. > **Note**:
+   > Don't confuse `RUN` with `CMD`. `RUN` actually runs a command and commits
+   > the result; `CMD` does not execute anything at build time, but specifies
+   > the intended command for the image.
 
 .. note::
 
-   ``RUN`` と ``CMD`` を混同しないでください。 ``RUN`` が実際に行っているのは、コマンドの実行と結果のコミットです。一方の ``CMD`` は構築時には何もしませんが、イメージで実行するコマンドを指定します。
+   ``RUN`` と ``CMD`` を混同しないようにしてください。
+   ``RUN`` は実際にコマンドが実行されて、結果を確定させます。
+   一方 ``CMD`` はイメージビルド時には何も実行しません。
+   イメージに対して実行する予定のコマンドを指示するものです。
 
 .. _builder-label:
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1306,9 +1306,11 @@ ADD されるファイルやディレクトリの UID と GID は、すべて 0 
   上の記述であれば、適切なファイルが見つけ出されます。
   （ ``http://example.com`` では正しく動作しません。）
 
-..    If <src> is a directory, the entire contents of the directory are copied, including filesystem metadata.
+.. - If `<src>` is a directory, the entire contents of the directory are copied,
+     including filesystem metadata.
 
-* ``<ソース>`` がディレクトリの場合、ディレクトリの内容の全てをコピーします。これにはファイルシステムのメタデータを含みます。
+* ``<src>`` がディレクトリである場合、そのディレクトリ内の内容がすべてコピーされます。
+  ファイルシステムのメタデータも含まれます。
 
   .. > **Note**:
      > The directory itself is not copied, just its contents.
@@ -1476,9 +1478,11 @@ COPY は２つの形式があります。
 * ``<src>`` のパス指定は、ビルド **コンテキスト** 内でなければならないため、たとえば ``COPY ../something /something`` といったことはできません。
   ``docker build`` の最初の処理ステップでは、コンテキスト・ディレクトリ（およびそのサブディレクトリ）を Docker デーモンに送信するところから始まるためです。
 
-..    If <src> is a directory, the entire contents of the directory are copied, including filesystem metadata.
+.. - If `<src>` is a directory, the entire contents of the directory are copied,
+     including filesystem metadata.
 
-* ``<ソース>`` がディレクトリの場合、ディレクトリ内容の全てをコピーします。これにはファイルシステムのメタデータを含みます。
+* ``<src>`` がディレクトリである場合、そのディレクトリ内の内容がすべてコピーされます。
+  ファイルシステムのメタデータも含まれます。
 
   .. > **Note**:
      > The directory itself is not copied, just its contents.

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1496,9 +1496,11 @@ COPY は２つの形式があります。
 * ``<src>`` が上に示す以外のファイルであった場合、メタデータも含めて個々にコピーされます。
   このとき ``<dest>`` が ``/`` で終わっていたらディレクトリとみなされるので、``<src>`` の内容は ``<dest>/base(<src>)`` に書き込まれることになります。
 
-..    If multiple <src> resources are specified, either directly or due to the use of a wildcard, then <dest> must be a directory, and it must end with a slash /.
+.. - If multiple `<src>` resources are specified, either directly or due to the
+     use of a wildcard, then `<dest>` must be a directory, and it must end with
+     a slash `/`.
 
-* もし複数の ``<ソース>`` リソースが指定された場合や、ディレクトリやワイルドカードを使った場合、 ``<送信先>`` は必ずディレクトリになり、最後はスラッシュ ``/`` にしなければいけません。
+* 複数の ``<src>`` が直接指定された場合、あるいはワイルドカードを用いて指定された場合、``<dest>`` はディレクトリとする必要があり、末尾には ``/`` をつけなければなりません。
 
 ..    If <dest> does not end with a trailing slash, it will be considered a regular file and the contents of <src> will be written at <dest>.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1318,9 +1318,15 @@ ADD されるファイルやディレクトリの UID と GID は、すべて 0 
       ディレクトリそのものはコピーされません。
       コピーされるのはその中身です。
 
-..    If <src> is a local tar archive in a recognized compression format (identity, gzip, bzip2 or xz) then it is unpacked as a directory. Resources from remote URLs are not decompressed. When a directory is copied or unpacked, it has the same behavior as tar -x: the result is the union of:
+.. - If `<src>` is a *local* tar archive in a recognized compression format
+     (identity, gzip, bzip2 or xz) then it is unpacked as a directory. Resources
+     from *remote* URLs are **not** decompressed. When a directory is copied or
+     unpacked, it has the same behavior as `tar -x`, the result is the union of:
 
-* もし ``<ソース>`` が *ローカル* にある tar アーカイブの場合、圧縮フォーマットを認識します（gzip、bzip2、xz を認識）。それからディレクトリに展開します。 *リモート* の URL が指定された場合は展開 **しません**。ディレクトリにコピーまたは展開する時は、 ``tar -x`` と同じ働きをします。結果は次の処理を同時に行います。
+* ``<src>`` が **ローカル** にある tar アーカイブであって、認識できるフォーマット（gzip、bzip2、xz）である場合、1 つのディレクトリ配下に展開されます。
+  **リモート** URL の場合は展開 **されません** 。
+  ディレクトリのコピーあるいは展開の仕方は ``tar -x`` と同等です。
+  つまりその結果は以下の 2 つのいずれかに従います。
 
 ..        Whatever existed at the destination path and
 ..        The contents of the source tree, with conflicts resolved in favor of “2.” on a file-by-file basis.

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1229,9 +1229,16 @@ ADD には 2 つの書式があります。
 
 ADD されるファイルやディレクトリの UID と GID は、すべて 0 として生成されます。
 
-.. In the case where <src> is a remote file URL, the destination will have permissions of 600. If the remote file being retrieved has an HTTP Last-Modified header, the timestamp from that header will be used to set the mtime on the destination file. However, like any other file processed during an ADD, mtime will not be included in the determination of whether or not the file has changed and the cache should be updated.
+.. In the case where `<src>` is a remote file URL, the destination will
+   have permissions of 600. If the remote file being retrieved has an HTTP
+   `Last-Modified` header, the timestamp from that header will be used
+   to set the `mtime` on the destination file. However, like any other file
+   processed during an `ADD`, `mtime` will not be included in the determination
+   of whether or not the file has changed and the cache should be updated.
 
-``<ソース>`` がリモート URL の場合は、送信先のパーミッションは 600 にします。もしリモートのファイルが HTTP ``Last-Modified`` ヘッダを返す場合は、このヘッダの情報を元に送信先ファイルの ``mtime`` を指定するのに使います。しかしながら、 ``ADD`` を使ったファイルをコピーする手順では、 ``mtime`` はファイルが更新されたかどうかの決定には使われず、ファイルが更新されればキャッシュも更新されます。
+``<src>`` にリモートファイル URL が指定された場合、コピー先のパーミッションは 600 となります。
+リモートファイルの取得時に HTTP の ``Last-Modified`` ヘッダが含まれている場合は、ヘッダに書かれたタイムスタンプを利用して、コピー先ファイルの ``mtime`` を設定します。
+ただし ``ADD`` によって処理されるファイルが何であっても、ファイルが変更されたかどうか、そしてキャッシュを更新するべきかどうかは ``mtime`` によって判断されるわけではありません。
 
 ..    Note: If you build by passing a Dockerfile through STDIN (docker build - < somefile), there is no build context, so the Dockerfile can only contain a URL based ADD instruction. You can also pass a compressed archive through STDIN: (docker build - < archive.tar.gz), the Dockerfile at the root of the archive and the rest of the archive will get used at the context of the build.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1389,9 +1389,10 @@ COPY は２つの形式があります。
 * ``COPY <src>... <dest>``
 * ``COPY ["<src>",... "<dest>"]`` （パスにホワイトスペースを含む場合にこの書式が必要）
 
-.. The COPY instruction copies new files or directories from <src> and adds them to the filesystem of the container at the path <dest>.
+.. The `COPY` instruction copies new files or directories from `<src>`
+   and adds them to the filesystem of the container at the path `<dest>`.
 
-``COPY`` 命令は ``<ソース>`` にある新しいファイルやディレクトリをコピーするもので、コンテナ内のファイルシステム上にある ``<送信先>`` に指定されたパスに追加します。
+``COPY`` 命令は ``<src>`` からファイルやディレクトリを新たにコピーして、コンテナ内のファイルシステムのパス ``<dest>`` に追加します。
 
 .. Multiple <src> resource may be specified but they must be relative to the source directory that is being built (the context of the build).
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1175,9 +1175,10 @@ ADD には 2 つの書式があります。
 * ``ADD <src>... <dest>``
 * ``ADD ["<src>",... "<dest>"]`` （この書式はホワイトスペースを含むパスを用いる場合に必要）
 
-.. The ADD instruction copies new files, directories or remote file URLs from <src> and adds them to the filesystem of the container at the path <dest>.
+.. The `ADD` instruction copies new files, directories or remote file URLs from `<src>`
+   and adds them to the filesystem of the image at the path `<dest>`.
 
-``ADD`` 命令は ``<ソース>`` にある新しいファイルやディレクトリをコピー、あるいはリモートの URL からコピーします。それから、コンテナ内のファイルシステム上にある ``送信先`` に指定されたパスに追加します。
+``ADD`` 命令は ``<src>`` に示されるファイル、ディレクトリ、リモートファイル URL をコピーして、イメージ内のファイルシステム上のパス ``<dest>`` にこれらを加えます。
 
 .. Multiple <src> resource may be specified but if they are files or directories then they must be relative to the source directory that is being built (the context of the build).
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1468,9 +1468,13 @@ COPY は２つの形式があります。
 
 ``COPY`` は以下のルールに従います。
 
-..    The <src> path must be inside the context of the build; you cannot COPY ../something /something, because the first step of a docker build is to send the context directory (and subdirectories) to the docker daemon.
+.. - The `<src>` path must be inside the *context* of the build;
+     you cannot `COPY ../something /something`, because the first step of a
+     `docker build` is to send the context directory (and subdirectories) to the
+     docker daemon.
 
-* ``<ソース>`` パスは、構築時の *コンテント* 内にある必要があります。そのため、 ``COPY ../something /something`` の指定はできません。 ``docker build`` の最初のステップで、コンテクストのディレクトリ（と、サブディレクトリ）を docker デーモンに送るためです。
+* ``<src>`` のパス指定は、ビルド **コンテキスト** 内でなければならないため、たとえば ``COPY ../something /something`` といったことはできません。
+  ``docker build`` の最初の処理ステップでは、コンテキスト・ディレクトリ（およびそのサブディレクトリ）を Docker デーモンに送信するところから始まるためです。
 
 ..    If <src> is a directory, the entire contents of the directory are copied, including filesystem metadata.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1180,9 +1180,12 @@ ADD には 2 つの書式があります。
 
 ``ADD`` 命令は ``<src>`` に示されるファイル、ディレクトリ、リモートファイル URL をコピーして、イメージ内のファイルシステム上のパス ``<dest>`` にこれらを加えます。
 
-.. Multiple <src> resource may be specified but if they are files or directories then they must be relative to the source directory that is being built (the context of the build).
+.. Multiple `<src>` resource may be specified but if they are files or
+   directories then they must be relative to the source directory that is
+   being built (the context of the build).
 
-複数の ``<ソース>`` リソースを指定できます。この時、ファイルやディレクトリはソースディレクトリ（構築時のコンテクスト）からの相対パス上に存在しないと構築できません。
+``<src>`` には複数のソースを指定することが可能です。
+ソースとしてファイルあるいはディレクトリが指定されている場合、そのパスは生成されたソース・ディレクトリ（ビルド・コンテキスト）からの相対パスでなければなりません。
 
 .. Each <src> may contain wildcards and matching will be done using Go’s filepath.Match rules. For example:
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -993,9 +993,9 @@ LABEL
 ラベルには ``FROM`` に指定されたイメージ内の ``LABEL`` 命令も含まれます。
 ラベルのキーが既に存在していた場合、そのキーに対応する古い値は、新しい値によって上書きされます。
 
-.. To view an image’s labels, use the docker inspect command.
+.. To view an image's labels, use the `docker inspect` command.
 
-イメージが使っているラベルを確認するには、 ``docker inspect`` コマンドを使います。
+イメージのラベルを参照するには ``docker inspect`` コマンドを用います。
 
 .. code-block:: bash
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1064,9 +1064,15 @@ EXPOSE
 利用できるようにするためには ``-p`` フラグを使ってポートの公開範囲を指定するか、 ``-P`` フラグによって expose したポートをすべて公開する必要があります。
 1 つのポート番号を expose して、これを外部に向けては別の番号により公開することも可能です。
 
-.. To set up port redirection on the host system, see using the -P flag. The Docker network feature supports creating networks without the need to expose ports within the network, for detailed information see the overview of this feature).
+.. To set up port redirection on the host system, see [using the -P
+   flag](run.md#expose-incoming-ports). The Docker network feature supports
+   creating networks without the need to expose ports within the network, for
+   detailed information see the  [overview of this
+   feature](https://docs.docker.com/engine/userguide/networking/)).
 
-ホストシステム上でポート転送を使うには、 :ref:`-P フラグを使う <expose-incoming-ports>` をご覧ください。Docker のネットワーク機能は、ネットワーク内でポートを公開しないネットワークを作成可能です。詳細な情報は :doc:`機能概要 </engine/userguide/networking/index>` をご覧ください。
+ホストシステム上にてポート転送を行う場合は、:ref:`-P フラグの利用 <expose-incoming-ports>` を参照してください。
+Docker のネットワークにおいては、ネットワーク内でポートを expose しなくてもネットワークを生成できる機能がサポートされています。
+詳しくは :doc:`ネットワーク機能の概要 </engine/userguide/networking/index>` を参照してください。
 
 .. _env:
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1104,9 +1104,15 @@ ENV
 全体の文字列のうち、最初の空白文字以降がすべて ``<value>`` として扱われます。
 そこには空白やクォートを含んでいて構いません。
 
-.. The second form, ENV <key>=<value> ..., allows for multiple variables to be set at one time. Notice that the second form uses the equals sign (=) in the syntax, while the first form does not. Like command line parsing, quotes and backslashes can be used to include spaces within values.
+.. The second form, `ENV <key>=<value> ...`, allows for multiple variables to
+   be set at one time. Notice that the second form uses the equals sign (=)
+   in the syntax, while the first form does not. Like command line parsing,
+   quotes and backslashes can be used to include spaces within values.
 
-２つめの形式は ``ENV <key>=<value> ...`` です。これは一度に複数の変数を指定できます。先ほどと違い、構文の２つめにイコールサイン（=）があるので気を付けてください。コマンドラインの分割、クォート、バックスラッシュは、空白スペースも含めて値になります。
+2 つめの書式は ``ENV <key>=<value> ...`` です。
+これは一度に複数の値を設定できる形です。
+この書式では等号（=）を用いており、1 つめの書式とは異なります。
+コマンドライン上の解析で行われることと同じように、クォートやバックスラッシュを使えば、値の中に空白などを含めることができます。
 
 .. For example:
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1168,11 +1168,12 @@ ADD
 
 ADD には 2 つの書式があります。
 
-..    ADD <src>... <dest>
-    ADD ["<src>",... "<dest>"] (this form is required for paths containing whitespace)
+.. - `ADD <src>... <dest>`
+   - `ADD ["<src>",... "<dest>"]` (this form is required for paths containing
+   whitespace)
 
-* ``ADD <ソース>... <送信先>``
-* ``ADD ["<ソース>", ... "<送信先>"]`` （この形式はパスに空白スペースを使う場合に必要）
+* ``ADD <src>... <dest>``
+* ``ADD ["<src>",... "<dest>"]`` （この書式はホワイトスペースを含むパスを用いる場合に必要）
 
 .. The ADD instruction copies new files, directories or remote file URLs from <src> and adds them to the filesystem of the container at the path <dest>.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1394,9 +1394,11 @@ COPY は２つの形式があります。
 
 ``COPY`` 命令は ``<src>`` からファイルやディレクトリを新たにコピーして、コンテナ内のファイルシステムのパス ``<dest>`` に追加します。
 
-.. Multiple <src> resource may be specified but they must be relative to the source directory that is being built (the context of the build).
+.. Multiple `<src>` resource may be specified but they must be relative
+   to the source directory that is being built (the context of the build).
 
-複数の ``<ソース>`` リソースを指定できます。この時、ソースディレクトリ（構築時のコンテクスト）からの相対パス上に存在しないと構築できません。
+``<src>`` には複数のソースを指定することが可能です。
+ソースとしてファイルあるいはディレクトリが指定されている場合、そのパスは生成されたソース・ディレクトリ（ビルド・コンテキスト）からの相対パスでなければなりません。
 
 .. Each <src> may contain wildcards and matching will be done using Go’s filepath.Match rules. For example:
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1507,9 +1507,10 @@ COPY は２つの形式があります。
 
 * ``<dest>`` の末尾にスラッシュがなかった場合、通常のファイルとみなされるため、``<src>`` の内容が ``<dest>`` に書き込まれます。
 
-..    If <dest> doesn’t exist, it is created along with all missing directories in its path.
+.. - If `<dest>` doesn't exist, it is created along with all missing directories
+     in its path.
 
-* ``<送信先>`` が存在しなければ、パスに存在しないディレクトリを作成します。
+* ``<dest>`` のパス内のディレクトリが存在しなかった場合、すべて生成されます。
 
 .. _entrypoint:
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1450,6 +1450,20 @@ COPY は２つの形式があります。
 
   ``Dockerfile`` を標準入力から生成する場合（ ``docker build - < somefile`` ）は、ビルド・コンテキストが存在していないことになるので、``COPY`` 命令は利用することができません。
 
+.. Optionally `COPY` accepts a flag `--from=<name|index>` that can be used to set
+   the source location to a previous build stage (created with `FROM .. AS <name>`)
+   that will be used instead of a build context sent by the user. The flag also 
+   accepts a numeric index assigned for all previous build stages started with 
+   `FROM` instruction. In case a build stage with a specified name can't be found an 
+   image with the same name is attempted to be used instead.
+
+オプションとして ``COPY`` にはフラグ ``--from=<name|index>`` があります。
+これは実行済のビルド・ステージ（ ``FROM .. AS <name>`` により生成）におけるソース・ディレクトリを設定するものです。
+これがあると、ユーザーが指定したビルド・コンテキストのかわりに、設定されたディレクトリが用いられます。
+このフラグは数値インデックスを指定することも可能です。
+この数値インデックスは、``FROM`` 命令から始まる実行済のビルド・ステージすべてに割り当てられている値です。
+指定されたビルド・ステージがその名前では見つけられなかった場合、指定された数値によって見つけ出します。
+
 .. COPY obeys the following rules:
 
 ``COPY`` は以下のルールに従います。

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1335,11 +1335,19 @@ ADD されるファイルやディレクトリの UID と GID は、すべて 0 
   1. コピー先に指定されていれば、それが存在しているかどうかに関わらず。あるいは、
   2. ソース・ツリーの内容に従って各ファイルごとに行う。衝突が発生した場合は 2. を優先する。
 
-.. Note: Whether a file is identified as a recognized compression format or not is done solely based on the contents of the file, not the name of the file. For example, if an empty file happens to end with .tar.gz this will not be recognized as a compressed file and will not generate any kind of decompression error message, rather the file will simply be copied to the destination.
+  .. > **Note**:
+     > Whether a file is identified as a recognized compression format or not
+     > is done solely based on the contents of the file, not the name of the file.
+     > For example, if an empty file happens to end with `.tar.gz` this will not
+     > be recognized as a compressed file and **will not** generate any kind of
+     > decompression error message, rather the file will simply be copied to the
+     > destination.
 
-.. note::
+  .. note::
 
-   ファイルが圧縮フォーマットと認識するか、あるいはファイルの集まりをベースにしているのかは、ファイルの名前では判断しません。例えば、空のファイル名の拡張子が ``.tar.gz`` だとしても、圧縮ファイルと認識しないため、展開エラーのメッセージを表示 **しません** 。そして単純に送信先にファイルをコピーします。
+     圧縮されたファイルが認識可能なフォーマットであるかどうかは、そのファイル内容に基づいて確認されます。
+     名前によって判断されるわけではありません。
+     たとえば、空のファイルの名前の末尾がたまたま ``.tar.gz`` となっていた場合、圧縮ファイルとして認識されないため、解凍に失敗したといったエラーメッセージは一切 **出ることはなく** 、このファイルはコピー先に向けて単純にコピーされるだけです。
 
 ..    If <src> is any other kind of file, it is copied individually along with its metadata. In this case, if <dest> ends with a trailing slash /, it will be considered a directory and the contents of <src> will be written at <dest>/base(<src>).
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1328,11 +1328,12 @@ ADD されるファイルやディレクトリの UID と GID は、すべて 0 
   ディレクトリのコピーあるいは展開の仕方は ``tar -x`` と同等です。
   つまりその結果は以下の 2 つのいずれかに従います。
 
-..        Whatever existed at the destination path and
-..        The contents of the source tree, with conflicts resolved in favor of “2.” on a file-by-file basis.
+  ..  1. Whatever existed at the destination path and
+      2. The contents of the source tree, with conflicts resolved in favor
+         of "2." on a file-by-file basis.
 
-1. 送信先のパスが存在しているかどうか
-2. ファイル単位の原則に従って、ソース・ツリーの内容と衝突しないかどうか「2」を繰り返す
+  1. コピー先に指定されていれば、それが存在しているかどうかに関わらず。あるいは、
+  2. ソース・ツリーの内容に従って各ファイルごとに行う。衝突が発生した場合は 2. を優先する。
 
 .. Note: Whether a file is identified as a recognized compression format or not is done solely based on the contents of the file, not the name of the file. For example, if an empty file happens to end with .tar.gz this will not be recognized as a compressed file and will not generate any kind of decompression error message, rather the file will simply be copied to the destination.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1368,9 +1368,10 @@ ADD されるファイルやディレクトリの UID と GID は、すべて 0 
 
 * ``<dest>`` の末尾にスラッシュがなかった場合、通常のファイルとみなされるため、``<src>`` の内容は ``<dest>`` に書き込まれることになります。
 
-..    If <dest> doesn’t exist, it is created along with all missing directories in its path.
+.. - If `<dest>` doesn't exist, it is created along with all missing directories
+     in its path.
 
-* ``<送信先>`` が存在しなければ、パスに存在しないディレクトリを作成します。
+* ``<dest>`` のパス内のディレクトリが存在しなかった場合、すべて生成されます。
 
 .. _copy:
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1293,9 +1293,18 @@ ADD されるファイルやディレクトリの UID と GID は、すべて 0 
 
 * ``<src>`` が URL 指定であって ``<dest>`` の最後にスラッシュが指定されていない場合、そのファイルを URL よりダウンロードして ``<dest>`` にコピーします。
 
-..    If <src> is a URL and <dest> does end with a trailing slash, then the filename is inferred from the URL and the file is downloaded to <dest>/<filename>. For instance, ADD http://example.com/foobar / would create the file /foobar. The URL must have a nontrivial path so that an appropriate filename can be discovered in this case (http://example.com will not work).
+.. - If `<src>` is a URL and `<dest>` does end with a trailing slash, then the
+     filename is inferred from the URL and the file is downloaded to
+     `<dest>/<filename>`. For instance, `ADD http://example.com/foobar /` would
+     create the file `/foobar`. The URL must have a nontrivial path so that an
+     appropriate filename can be discovered in this case (`http://example.com`
+     will not work).
 
-* もし ``<ソース>`` が URL であり、 ``<送信先>`` の末尾がスラッシュの場合、URL からファイル名を推測し、ファイルを ``<送信先>/<ファイル名>`` にダウンロードします。例えば、 ``ADD http://example.com/foobar /`` は、 ``/foobar`` ファイルを作成します。URL には何らかのパスが必要です。これは適切なファイル名を見つけられない場合があるためです（今回の例では、 ``http://example.com`` の指定は動作しません）。
+* ``<src>`` が URL 指定であって ``<dest>`` の最後にスラッシュが指定された場合、ファイルが指定されたものとして扱われ、URL からダウンロードして ``<dest>/<filename>`` にコピーします。
+  たとえば ``ADD http://example.com/foobar /`` という記述は ``/foobar`` というファイルを作ることになります。
+  URL には正確なパス指定が必要です。
+  上の記述であれば、適切なファイルが見つけ出されます。
+  （ ``http://example.com`` では正しく動作しません。）
 
 ..    If <src> is a directory, the entire contents of the directory are copied, including filesystem metadata.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -853,11 +853,14 @@ CMD
 
    ``ENTRYPOINT`` 命令に対するデフォルト引数を設定する目的で ``CMD`` 命令を用いる場合、``CMD`` と ``ENTRYPOINT`` の両命令とも、JSON 配列形式で指定しなければなりません。
 
-..     Note: The exec form is parsed as a JSON array, which means that you must use double-quotes (“) around words not single-quotes (‘).
+.. > **Note**:
+   > The *exec* form is parsed as a JSON array, which means that
+   > you must use double-quotes (") around words not single-quotes (').
 
 .. note::
 
-   *exec* 形式は JSON 配列でパースされます。つまり、文字を囲むのはシングル・クォート(') ではなくダブル・クォート(")を使う必要があります。
+   exec 形式は JSON 配列として解釈されます。
+   したがって文字列をくくるのはダブル・クォート（"）であり、シングル・クォート（'）は用いてはなりません。
 
 ..     Note: Unlike the shell form, the exec form does not invoke a command shell. This means that normal shell processing does not happen. For example, CMD [ "echo", "$HOME" ] will not do variable substitution on $HOME. If you want shell processing then either use the shell form or execute a shell directly, for example: CMD [ "sh", "-c", "echo", "$HOME" ].
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1187,9 +1187,12 @@ ADD には 2 つの書式があります。
 ``<src>`` には複数のソースを指定することが可能です。
 ソースとしてファイルあるいはディレクトリが指定されている場合、そのパスは生成されたソース・ディレクトリ（ビルド・コンテキスト）からの相対パスでなければなりません。
 
-.. Each <src> may contain wildcards and matching will be done using Go’s filepath.Match rules. For example:
+.. Each `<src>` may contain wildcards and matching will be done using Go's
+   [filepath.Match](http://golang.org/pkg/path/filepath#Match) rules. For example:
 
-それぞれの ``<ソース>`` にはワイルドカードと Go 言語の `filepath.Match <http://golang.org/pkg/path/filepath#Match>`_ ルールに一致するパターンが使えます。例えば、次のような記述です。
+``<src>`` にはワイルドカードを含めることができます。
+その場合、マッチング処理は Go 言語の `filepath.Match <http://golang.org/pkg/path/filepath#Match>`_ ルールに従って行われます。
+記述例は以下のとおりです。
 
 .. code-block:: dockerfile
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -844,11 +844,14 @@ CMD
 この処理設定においては、実行モジュールを含める場合と、実行モジュールを省略する場合があります。
 省略する場合は ``ENTRYPOINT`` 命令を合わせて指定する必要があります。
 
-..     Note: If CMD is used to provide default arguments for the ENTRYPOINT instruction, both the CMD and ENTRYPOINT instructions should be specified with the JSON array format.
+.. > **Note**:
+   > If `CMD` is used to provide default arguments for the `ENTRYPOINT`
+   > instruction, both the `CMD` and `ENTRYPOINT` instructions should be specified
+   > with the JSON array format.
 
 .. note::
 
-   ``ENTRYPOINT`` 命令のデフォルトの引数として ``CMD`` を使う場合、 ``CMD`` と ``ENTRYPOINT`` 命令の両方が JSON 配列フォーマットになっている必要があります。
+   ``ENTRYPOINT`` 命令に対するデフォルト引数を設定する目的で ``CMD`` 命令を用いる場合、``CMD`` と ``ENTRYPOINT`` の両命令とも、JSON 配列形式で指定しなければなりません。
 
 ..     Note: The exec form is parsed as a JSON array, which means that you must use double-quotes (“) around words not single-quotes (‘).
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -943,9 +943,15 @@ LABEL
 
    LABEL <key>=<value> <key>=<value> <key>=<value> ...
 
-.. The LABEL instruction adds metadata to an image. A LABEL is a key-value pair. To include spaces within a LABEL value, use quotes and backslashes as you would in command-line parsing. A few usage examples:
+.. The `LABEL` instruction adds metadata to an image. A `LABEL` is a
+   key-value pair. To include spaces within a `LABEL` value, use quotes and
+   backslashes as you would in command-line parsing. A few usage examples:
 
-``LABEL`` 命令はイメージにメタデータを追加します。 ``LABEL`` はキーとバリューのペアです。 ``LABEL`` の値に空白スペースを含む場合はクォートを使いますし、コマンドラインの分割にバックスラッシュを使います。使用例：
+``LABEL`` 命令はイメージに対してメタデータを追加します。
+``LABEL`` ではキーバリューペアによる記述を行います。
+値に空白などを含める場合は、クォートとバックスラッシュを用います。
+これはコマンドライン処理において行うことと同じです。
+以下に簡単な例を示します。
 
 .. code-block:: dockerfile
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -917,9 +917,10 @@ CMD
 コンテナにおいて毎回同じ実行モジュールを起動させたい場合は、``CMD`` 命令と ``ENTRYPOINT`` 命令を合わせて利用することを考えてみてください。
 :ref:`ENTRYPOINT <entrypoint>` を参照のこと。
 
-.. If the user specifies arguments to docker run then they will override the default specified in CMD.
+.. If the user specifies arguments to `docker run` then they will override the
+   default specified in `CMD`.
 
-ユーザが ``docker run`` で引数を指定した時、これらは ``CMD`` で指定したデフォルトを上書きします。
+``docker run`` において引数を指定することで、``CMD`` 命令に指定されたデフォルトを上書きすることができます。
 
 ..    Note: don’t confuse RUN with CMD. RUN actually runs a command and commits the result; CMD does not execute anything at build time, but specifies the intended command for the image.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1442,11 +1442,13 @@ COPY は２つの形式があります。
 
 コピーされるファイルやディレクトリの UID と GID は、すべて 0 として生成されます。
 
-..    Note: If you build using STDIN (docker build - < somefile), there is no build context, so COPY can’t be used.
+.. > **Note**:
+   > If you build using STDIN (`docker build - < somefile`), there is no
+   > build context, so `COPY` can't be used.
 
 .. note::
 
-   標準入力（ ``docker build - < 何らかのファイル`` ）を使って構築しようとしても、構築時のコンテントは存在しないため、 ``COPY`` を使えません。
+  ``Dockerfile`` を標準入力から生成する場合（ ``docker build - < somefile`` ）は、ビルド・コンテキストが存在していないことになるので、``COPY`` 命令は利用することができません。
 
 .. COPY obeys the following rules:
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1093,9 +1093,16 @@ ENV
 ``Dockerfile`` 内の後続命令の環境において、環境変数の値は維持されます。
 また、いろいろと :ref:`インラインにて変更 <environment-replacement>` することもできます。
 
-.. The ENV instruction has two forms. The first form, ENV <key> <value>, will set a single variable to a value. The entire string after the first space will be treated as the <value> - including characters such as spaces and quotes.
+.. The `ENV` instruction has two forms. The first form, `ENV <key> <value>`,
+   will set a single variable to a value. The entire string after the first
+   space will be treated as the `<value>` - including characters such as
+   spaces and quotes.
 
-``ENV`` 命令は２つの形式があります。１つめは、 ``ENV <key> <value>`` であり、変数に対して１つの値を設定します。はじめの空白以降の文字列が ``<value>`` に含まれます。ここには空白もクォートも含まれます。
+``ENV`` 命令には 2 つの書式があります。
+1 つめの書式は ``ENV <key> <value>`` です。
+1 つの変数に対して 1 つの値を設定します。
+全体の文字列のうち、最初の空白文字以降がすべて ``<value>`` として扱われます。
+そこには空白やクォートを含んでいて構いません。
 
 .. The second form, ENV <key>=<value> ..., allows for multiple variables to be set at one time. Notice that the second form uses the equals sign (=) in the syntax, while the first form does not. Like command line parsing, quotes and backslashes can be used to include spaces within values.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1052,9 +1052,17 @@ EXPOSE
 
    EXPOSE <port> [<port>...]
 
-.. The EXPOSE instruction informs Docker that the container listens on the specified network ports at runtime. EXPOSE does not make the ports of the container accessible to the host. To do that, you must use either the -p flag to publish a range of ports or the -P flag to publish all of the exposed ports. You can expose one port number and publish it externally under another number.
+.. The `EXPOSE` instruction informs Docker that the container listens on the
+   specified network ports at runtime. `EXPOSE` does not make the ports of the
+   container accessible to the host. To do that, you must use either the `-p` flag
+   to publish a range of ports or the `-P` flag to publish all of the exposed
+   ports. You can expose one port number and publish it externally under another
+   number.
 
-``EXPOSE`` 命令は、特定のネットワーク・ポートをコンテナが実行時にリッスンすることを Docker に伝えます。 ``EXPOSE`` があっても、これだけではホストからコンテナにアクセスできるようにしません。アクセスするには、 ``-p`` フラグを使ってポートの公開範囲を指定するか、 ``-P`` フラグで全ての露出ポートを公開する必要があります。外部への公開時は他のポート番号も利用可能です。
+``EXPOSE`` 命令はコンテナの実行時に、所定ネットワーク上のどのポートをリッスンするかを指定します。
+``EXPOSE`` はコンテナーのポートをホストが利用できるようにするものではありません。
+利用できるようにするためには ``-p`` フラグを使ってポートの公開範囲を指定するか、 ``-P`` フラグによって expose したポートをすべて公開する必要があります。
+1 つのポート番号を expose して、これを外部に向けては別の番号により公開することも可能です。
 
 .. To set up port redirection on the host system, see using the -P flag. The Docker network feature supports creating networks without the need to expose ports within the network, for detailed information see the overview of this feature).
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -881,9 +881,10 @@ CMD
    たとえば ``RUN [ "sh", "-c", "echo $HOME" ]`` とします。
    exec 形式によってシェルを直接起動した場合、シェル形式の場合でも同じですが、変数置換を行うのはシェルであって、docker ではありません。
 
-.. When used in the shell or exec formats, the CMD instruction sets the command to be executed when running the image.
+.. When used in the shell or exec formats, the `CMD` instruction sets the command
+   to be executed when running the image.
 
-シェルあるいは exec 形式を使う時、 ``CMD`` 命令はイメージで実行するコマンドを指定します。
+シェル形式または exec 形式を用いる場合、``CMD`` 命令は、イメージが起動されたときに実行するコマンドを指定します。
 
 .. If you use the shell form of the CMD, then the <command> will execute in /bin/sh -c:
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -862,11 +862,24 @@ CMD
    exec 形式は JSON 配列として解釈されます。
    したがって文字列をくくるのはダブル・クォート（"）であり、シングル・クォート（'）は用いてはなりません。
 
-..     Note: Unlike the shell form, the exec form does not invoke a command shell. This means that normal shell processing does not happen. For example, CMD [ "echo", "$HOME" ] will not do variable substitution on $HOME. If you want shell processing then either use the shell form or execute a shell directly, for example: CMD [ "sh", "-c", "echo", "$HOME" ].
+.. > **Note**:
+   > Unlike the *shell* form, the *exec* form does not invoke a command shell.
+   > This means that normal shell processing does not happen. For example,
+   > `CMD [ "echo", "$HOME" ]` will not do variable substitution on `$HOME`.
+   > If you want shell processing then either use the *shell* form or execute
+   > a shell directly, for example: `CMD [ "sh", "-c", "echo $HOME" ]`.
+   > When using the exec form and executing a shell directly, as in the case for
+   > the shell form, it is the shell that is doing the environment variable
+   > expansion, not docker.
 
 .. note::
 
-   *シェル* 形式と異なり、 *exec* 形式はコマンド・シェルを呼び出しません。つまり、通常のシェルによる処理が行われません。例えば ``CMD [ "echo", "$HOME" ]`` は ``$HOME`` の変数展開を行いません。シェルによる処理を行いたい場合は、 *シェル* 形式を使うか、あるいはシェルを直接使います。例： ``CMD [ "sh", "-c", "echo", "$HOME" ]`` 。
+   シェル形式とは違って exec 形式はコマンドシェルを起動しません。
+   これはつまり、ごく普通のシェル処理とはならないということです。
+   たとえば ``RUN [ "echo", "$HOME" ]`` を実行したとすると、``$HOME`` の変数置換は行われません。
+   シェル処理が行われるようにしたければ、シェル形式を利用するか、あるいはシェルを直接実行するようにします。
+   たとえば ``RUN [ "sh", "-c", "echo $HOME" ]`` とします。
+   exec 形式によってシェルを直接起動した場合、シェル形式の場合でも同じですが、変数置換を行うのはシェルであって、docker ではありません。
 
 .. When used in the shell or exec formats, the CMD instruction sets the command to be executed when running the image.
 

--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -910,9 +910,12 @@ CMD
    FROM ubuntu
    CMD ["/usr/bin/wc","--help"]
 
-.. If you would like your container to run the same executable every time, then you should consider using ENTRYPOINT in combination with CMD. See ENTRYPOINT.
+.. If you would like your container to run the same executable every time, then
+   you should consider using `ENTRYPOINT` in combination with `CMD`. See
+   [*ENTRYPOINT*](#entrypoint).
 
-もしコンテナで毎回同じものを実行するのであれば、 ``CMD`` と ``ENTRYPOINT`` の使用を検討ください。詳細は :ref:`ENTRYPOINT <entrypoint>` をご覧ください。
+コンテナにおいて毎回同じ実行モジュールを起動させたい場合は、``CMD`` 命令と ``ENTRYPOINT`` 命令を合わせて利用することを考えてみてください。
+:ref:`ENTRYPOINT <entrypoint>` を参照のこと。
 
 .. If the user specifies arguments to docker run then they will override the default specified in CMD.
 


### PR DESCRIPTION
訳修正案 /engine/reference/builder その２ です。

誤訳指摘、数点。 原文変更 10点ほどです。