### PR TITLE
Update django.rst

### DIFF
--- a/compose/django.rst
+++ b/compose/django.rst
@@ -110,6 +110,8 @@ Dockerfile はアプリケーションのイメージ内容に含まれる、１
    services:
      db:
        image: postgres
+       environment:
+         POSTGRES_PASSWORD: "postgres"
      web:
        build: .
        command: python manage.py runserver 0.0.0.0:8000
@@ -220,6 +222,7 @@ Docker を Mac あるいは Windows 上で動かしている場合は、 ``djang
            'ENGINE': 'django.db.backends.postgresql_psycopg2',
            'NAME': 'postgres',
            'USER': 'postgres',
+           'PASSWORD': 'postgres',
            'HOST': 'db',
            'PORT': 5432,
        }


### PR DESCRIPTION
Add PASSWORD environment variables.

If I don't set the PASSWORD, DB and WEB cause an error.

> db_1   | Error: Database is uninitialized and superuser password is not specified.
> db_1   |        You must specify POSTGRES_PASSWORD to a non-empty value for the
> db_1   |        superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".