### PR TITLE
カスタムネットワーク作成時のMTU指定オプションの間違いを修正

### DIFF
--- a/engine/reference/commandline/network_create.rst
+++ b/engine/reference/commandline/network_create.rst
@@ -195,7 +195,7 @@ Usage:  docker network create [OPTIONS]
    * - ``com.docker.network.bridge.host_binding_ipv4``
      - ``--ip``
      - コンテナのポートをバインドする時の、デフォルト IP アドレスを指定
-   * - ``com.docker.network.bridge.mtu``
+   * - ``com.docker.network.driver.mtu``
      - ``--mtu``
      - コンテナのネットワーク MTU を指定
 


### PR DESCRIPTION
(誤) com.docker.network.bridge.mtu
(正) com.docker.network.driver.mtu

下記URLとの比較、および動作検証済み
https://docs.docker.com/engine/reference/commandline/network_create/#bridge-driver-options