### PR TITLE
訳修正案 /engine/security/non-events

### DIFF
--- a/engine/security/non-events.rst
+++ b/engine/security/non-events.rst
@@ -43,7 +43,7 @@ Docker においては、バグに対する軽減対応がなされています�
 
 .. Bugs mitigated:
 
-バグへの対処済み（Bugs mitigated）：
+バグ（軽減対応あり）
 
 ..    CVE-2013-1956, 1957, 1958, 1959, 1979, CVE-2014-4014, 5206, 5207, 7970, 7975, CVE-2015-2925, 8543, CVE-2016-3134, 3135, etc.: The introduction of unprivileged user namespaces lead to a huge increase in the attack surface available to unprivileged users by giving such users legitimate access to previously root-only system calls like mount(). All of these CVEs are examples of security vulnerabilities due to introduction of user namespaces. Docker can use user namespaces to set up containers, but then disallows the process inside the container from creating its own nested namespaces through the default seccomp profile, rendering these vulnerabilities unexploitable.
 

--- a/engine/security/non-events.rst
+++ b/engine/security/non-events.rst
@@ -108,9 +108,13 @@ Docker においては、バグに対する軽減対応がなされています�
   Docker では、AppArmor、seccomp、そして ``CAP_PTRACE`` の削除により、コンテナ内での ``ptrace()`` を無効にしています。
   ここでは三重の防御が行われているわけです。
 
-..     CVE-2014-9529: A series of crafted keyctl() calls could cause kernel DoS / memory corruption. Docker disables keyctl() inside containers using seccomp.
+.. * [CVE-2014-9529](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-9529):
+   A series of crafted `keyctl()` calls could cause kernel DoS / memory corruption.
+   Docker disables `keyctl()` inside containers using seccomp.
 
-* `CVE-2014-9529 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-9529>`_ ： 連続する ``keyctl()`` コールの作成により、カーネルの DoS やメモリ不正を引き起こす可能性があります。Docker は seccomp を使い、コンテナ内での ``keyctl()`` を無効化します。
+* `CVE-2014-9529 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-9529>`_：
+  巧妙に仕掛けられた ``keyctl()`` 呼び出しを繰り返すことによって、カーネル DoS 攻撃やメモリ破壊を行います。
+  Docker では seccomp を利用して、コンテナ内部での ``keyctl()`` を無効にしています。
 
 ..     CVE-2015-3214, 4036: These are bugs in common virtualization drivers which could allow a guest OS user to execute code on the host OS. Exploiting them requires access to virtualization devices in the guest. Docker hides direct access to these devices when run without --privileged. Interestingly, these seem to be cases where containers are “more secure” than a VM, going against common wisdom that VMs are “more secure” than containers.
 

--- a/engine/security/non-events.rst
+++ b/engine/security/non-events.rst
@@ -116,9 +116,22 @@ Docker においては、バグに対する軽減対応がなされています�
   巧妙に仕掛けられた ``keyctl()`` 呼び出しを繰り返すことによって、カーネル DoS 攻撃やメモリ破壊を行います。
   Docker では seccomp を利用して、コンテナ内部での ``keyctl()`` を無効にしています。
 
-..     CVE-2015-3214, 4036: These are bugs in common virtualization drivers which could allow a guest OS user to execute code on the host OS. Exploiting them requires access to virtualization devices in the guest. Docker hides direct access to these devices when run without --privileged. Interestingly, these seem to be cases where containers are “more secure” than a VM, going against common wisdom that VMs are “more secure” than containers.
+.. * [CVE-2015-3214](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3214),
+   [4036](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4036): These are
+   bugs in common virtualization drivers which could allow a guest OS user to
+   execute code on the host OS. Exploiting them requires access to virtualization
+   devices in the guest. Docker hides direct access to these devices when run
+   without `--privileged`. Interestingly, these seem to be cases where containers
+   are "more secure" than a VM, going against common wisdom that VMs are
+   "more secure" than containers.
 
-* `CVE-2015-3214 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3214>`_  、 `4036 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4036>`_ ： これらのバグは共通の仮想化ドライバによるもので、ゲスト OS のユーザがホスト上のコードを実行できる可能性があります。これら不正な攻撃のためには、ゲスト内の仮想化デバイスにアクセスできる必要があります。Docker は、 ``--privileged`` を使って実行しなければ 、これらデバイスへの直接アクセスを隠すようにします。興味深いことに、場合によってはコンテナが仮想マシンよりも「より安全」になるのですが、これは、共通の優れた認識とは相反します。仮想マシンがコンテナよりも「より安全」です。
+* `CVE-2015-3214 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3214>`_、
+  `4036 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4036>`_：
+  仮想ドライバによく見られるバグであり、ゲスト OS のユーザがホスト OS 上のコードを実行できてしまうものです。
+  これを悪用するには、ゲスト内の仮想デバイスにアクセスする必要があります。
+  Docker では ``--privileged`` の指定がない場合は、そういったデバイスへの直接アクセスを隠蔽します。
+  ここがおもしろいところで、このケースが、VM よりもコンテナの方が「より安全」と言えるかもしれない点です。
+  つまりコンテナよりも VM の方が「より安全」とされる常識に反している例です。
 
 ..     CVE-2016-0728: Use-after-free caused by crafted keyctl() calls could lead to privilege escalation. Docker disables keyctl() inside containers using the default seccomp profile.
 

--- a/engine/security/non-events.rst
+++ b/engine/security/non-events.rst
@@ -45,9 +45,47 @@ Docker においては、バグに対する軽減対応がなされています�
 
 バグ（軽減対応あり）
 
-..    CVE-2013-1956, 1957, 1958, 1959, 1979, CVE-2014-4014, 5206, 5207, 7970, 7975, CVE-2015-2925, 8543, CVE-2016-3134, 3135, etc.: The introduction of unprivileged user namespaces lead to a huge increase in the attack surface available to unprivileged users by giving such users legitimate access to previously root-only system calls like mount(). All of these CVEs are examples of security vulnerabilities due to introduction of user namespaces. Docker can use user namespaces to set up containers, but then disallows the process inside the container from creating its own nested namespaces through the default seccomp profile, rendering these vulnerabilities unexploitable.
+.. * [CVE-2013-1956](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1956),
+   [1957](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1957),
+   [1958](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1958),
+   [1959](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1959),
+   [1979](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1979),
+   [CVE-2014-4014](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-4014),
+   [5206](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-5206),
+   [5207](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-5207),
+   [7970](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-7970),
+   [7975](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-7975),
+   [CVE-2015-2925](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-2925),
+   [8543](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8543),
+   [CVE-2016-3134](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3134),
+   [3135](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3135), etc.:
+   The introduction of unprivileged user namespaces lead to a huge increase in the
+   attack surface available to unprivileged users by giving such users legitimate
+   access to previously root-only system calls like `mount()`. All of these CVEs
+   are examples of security vulnerabilities due to introduction of user namespaces.
+   Docker can use user namespaces to set up containers, but then disallows the
+   process inside the container from creating its own nested namespaces through the
+   default seccomp profile, rendering these vulnerabilities unexploitable.
 
-* `CVE-2013-1956 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1956>`_ 、 `1957 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1957>`_ 、 `1958 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1958>`_ 、 `1959 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1959>`_ 、 `1979 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1979>`_ 、 `CVE-2014-4014 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-4014>`_ 、 `5206 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-5206>`_ 、 `5207 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-5207>`_ 、 `7970 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-7970>`_ 、 `7975 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-7975>`_ 、 `CVE-2015-2925 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-2925>`_ 、 `8543 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8543>`_ 、 `CVE-2016-3134  <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3134>`_ 、 `3135 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3135>`_ 、  等 ： 特権のないユーザ名前区間（unprivileged user namespaces）の導入は、特権のないユーザからの攻撃機会を大いに増加させました。たとえば、 ``mount()`` のように、以前は root のみのシステムコールに対し、権限のないユーザの利用を正当化するものです。これら全てのセキュリティ脆弱性例は、ユーザ名前空間（user namespaces）の導入に起因しています。Docker はユーザ名前空間を使ってコンテナをセットアップしますが、デフォルトの seccomp プロファイルでは、コンテナ内のプロセスに対しては、自身からネストする名前空間の作成を許可しませんので、これら脆弱性は利用されていないと解釈しています。
+* `CVE-2013-1956 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1956>`_、
+  `1957 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1957>`_、
+  `1958 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1958>`_、
+  `1959 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1959>`_、
+  `1979 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1979>`_、
+  `CVE-2014-4014 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-4014>`_、
+  `5206 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-5206>`_、
+  `5207 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-5207>`_、
+  `7970 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-7970>`_、
+  `7975 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-7975>`_、
+  `CVE-2015-2925 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-2925>`_、
+  `8543 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8543>`_、
+  `CVE-2016-3134 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3134>`_、
+  `3135 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3135>`_ など:
+  非特権ユーザによる名前空間が導入されたことにより、非特権ユーザでもアクセス可能な場所への攻撃が大幅に増えることになりました。
+  ``mount()`` のように従来なら root 権限でしかアクセスできなかったシステムコールが、非特権ユーザであっても正当にアクセスできるようになってしまったからです。
+  ここにあげた CVE はすべて、ユーザ名前空間の導入にともなうセキュリティぜい弱性の例です。
+  Docker ではコンテナの設定時にユーザ名前空間を利用します。
+  しかしデフォルトの seccomp プロファイルを通じて、コンテナ内のプロセスにおいては、ネスト化した名前空間の生成ができなくなっており、そのぜい弱性は悪用できなくなっています。
 
 ..     CVE-2014-0181, CVE-2015-3339: These are bugs that require the presence of a setuid binary. Docker disables setuid binaries inside containers via the NO_NEW_PRIVS process flag and other mechanisms.
 

--- a/engine/security/non-events.rst
+++ b/engine/security/non-events.rst
@@ -176,9 +176,20 @@ Docker においては、バグに対する軽減対応がなされています�
   Docker コンテナ内での悪用が可能です。
   現時点においてシステムコール ``modify_ldt()`` が seccomp を使ってもブロックできないためです。
 
-..     CVE-2016-5195: A race condition was found in the way the Linux kernel’s memory subsystem handled the copy-on-write (COW) breakage of private read-only memory mappings, which allowed unprivileged local users to gain write access to read-only memory. Also known as “dirty COW.” Partial mitigations: on some operating systems this vulnerability is mitigated by the combination of seccomp filtering of ptrace and the fact that /proc/self/mem is read-only.
+.. * [CVE-2016-5195](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5195):
+   A race condition was found in the way the Linux kernel's memory subsystem
+   handled the copy-on-write (COW) breakage of private read-only memory mappings,
+   which allowed unprivileged local users to gain write access to read-only memory.
+   Also known as "dirty COW."
+   *Partial mitigations:* on some operating systems this vulnerability is mitigated
+   by the combination of seccomp filtering of `ptrace` and the fact that `/proc/self/mem` is read-only.
 
-* `CVE-2016-5195 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5195>`_ ： 非常に稀なケースが発見されました。Linux カーネルのメモリ・サブシステムが扱うコピーオンライト（COW）が、プライベートな読み込み専用のメモリ・マッピングを破損します。これにより、権限のないローカルユーザが、読み込み専用のメモリに対する書き込みの権限を得られるというものです。これはまた「dirty COW」とも知られています。部分的な対処：いくつかのオペレーティングシステムでは、この脆弱性を ``ptrace`` の seccomp フィルタリングと、実際には ``/proc/self/mem`` を読み込み専用にすることを組み合わせ対処しています。
+* `CVE-2016-5195 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5195>`_：
+  Linux カーネルのメモリ・サブシステムがコピーオンライト（copy-on-write; COW）を扱う際に、競合状態が発生し、プライベートな読み込み専用メモリのマッピングが破損してしまうことがわかりました。
+  この際にローカルの非特権ユーザが、読み込み専用メモリへの書き込み権限を有してしまうことが起こります。
+  これは 「Dirty COW」とも呼ばれます。
+  **部分的なバグ軽減:** オペレーティング・システムの中には、このぜい弱性を軽減できているものがあります。
+  そこでは seccomp の ``ptrace`` に対するフィルタリングと、``/proc/self/mem`` が読み込み専用であることを利用して対処しています。
 
 .. seealso:: 
 

--- a/engine/security/non-events.rst
+++ b/engine/security/non-events.rst
@@ -146,9 +146,19 @@ Docker においては、バグに対する軽減対応がなされています�
 
 * `CVE-2016-2383 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2383>`_ ： eBPF のバグです。特別なカーネル内の DSL が、seccomp ファイルかのように装うことで、カーネルメモリを任意に読み込み可能にします。コンテナ内で（皮肉にも） seccomp を使ってブロックされます。
 
-..     CVE-2016-3134, 4997, 4998: A bug in setsockopt with IPT_SO_SET_REPLACE, ARPT_SO_SET_REPLACE, and ARPT_SO_SET_REPLACE causing memory corruption / local privilege escalation. These arguments are blocked by CAP_NET_ADMIN, which Docker does not allow by default.
+.. * [CVE-2016-3134](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3134),
+   [4997](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4997),
+   [4998](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4998):
+   A bug in setsockopt with `IPT_SO_SET_REPLACE`, `ARPT_SO_SET_REPLACE`,  and
+   `ARPT_SO_SET_REPLACE` causing memory corruption / local privilege escalation.
+   These arguments are blocked by `CAP_NET_ADMIN`, which Docker does not allow by
+   default.
 
-* `CVE-2016-3134 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3134>`_ 、 `4997 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4997>`_ 、 `4998 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4998>`_  ： setsockopt の ``IPT_SO_SET_REPLACE`` 、 ``ARPT_SO_SET_REPLACE`` 、 ``ARPT_SO_SET_REPLACE`` にあるバグで、メモリ不正やローカル権限の昇格を引き起こす可能性があります。デフォルトの Docker は、これらの引数を ``CAP_NET_ADMIN`` によってブロックします。
+* `CVE-2016-3134 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3134>`_、
+  `4997 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4997>`_、
+  `4998 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4998>`_：
+  setsockopt の ``IPT_SO_SET_REPLACE``、``ARPT_SO_SET_REPLACE``、``ARPT_SO_SET_REPLACE`` を利用することで、メモリ破壊、ローカル権限昇格を可能にしてしまうバグです。
+  これらの引数は ``CAP_NET_ADMIN`` によってブロックでき、Docker ではデフォルトで許可していません。
 
 .. Bugs not mitigated:
 

--- a/engine/security/non-events.rst
+++ b/engine/security/non-events.rst
@@ -19,9 +19,15 @@
    .. contents:: 
        :depth: 3
 
-.. This page lists security vulnerabilities which Docker mitigated, such that processes run in Docker containers were never vulnerable to the bug—even before it was fixed. This assumes containers are run without adding extra capabilities or not run as --privileged.
+.. This page lists security vulnerabilities which Docker mitigated, such that
+   processes run in Docker containers were never vulnerable to the bug—even before
+   it was fixed. This assumes containers are run without adding extra capabilities
+   or not run as `--privileged`.
 
-このページは Docker に影響を与えるセキュリティ脆弱性の一覧です。この中には、 Docker コンテナとして実行するプロセスがバグによる影響を受けていなくても、また、たとえそれが修正されたものも含みます。前提として、コンテナの実行にあたっては、外部のケーパビリティ（capability）を追加しておらず、また、 ``--privileged`` としても実行してないものとします。
+このページではセキュリティぜい弱性一覧を示します。
+Docker においては、バグに対する軽減対応がなされています。
+もっとも Docker コンテナにおいて起動するプロセスでは、たとえバグ修正されなくても、元からぜい弱性があるとは言えません。
+ここではコンテナの起動にあたって、ケーパビリティは追加せず、あるいは ``--privileged`` としては起動していないことを前提とします。
 
 .. The list below is not even remotely complete. Rather, it is a sample of the few bugs we’ve actually noticed to have attracted security review and publicly disclosed vulnerabilities. In all likelihood, the bugs that haven’t been reported far outnumber those that have. Luckily, since Docker’s approach to secure by default through apparmor, seccomp, and dropping capabilities, it likely mitigates unknown bugs just as well as it does known ones.
 

--- a/engine/security/non-events.rst
+++ b/engine/security/non-events.rst
@@ -87,9 +87,16 @@ Docker においては、バグに対する軽減対応がなされています�
   Docker ではコンテナの設定時にユーザ名前空間を利用します。
   しかしデフォルトの seccomp プロファイルを通じて、コンテナ内のプロセスにおいては、ネスト化した名前空間の生成ができなくなっており、そのぜい弱性は悪用できなくなっています。
 
-..     CVE-2014-0181, CVE-2015-3339: These are bugs that require the presence of a setuid binary. Docker disables setuid binaries inside containers via the NO_NEW_PRIVS process flag and other mechanisms.
+.. * [CVE-2014-0181](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-0181),
+   [CVE-2015-3339](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3339):
+   These are bugs that require the presence of a setuid binary. Docker disables
+   setuid binaries inside containers via the `NO_NEW_PRIVS` process flag and
+   other mechanisms.
 
-* `CVE-2014-0181 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-0181>`_  、 `CVE-2015-3339 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3339>`_ ：これらのバグには、 setuid バイナリの存在が必要です。Docker は ``NO_NEW_PRIVS`` プロセス・フラグと他の仕組みにより、 コンテナ内での setuid バイナリを無効化します。
+* `CVE-2014-0181 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-0181>`_、
+  `CVE-2015-3339 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3339>`_：
+  これは setuid バイナリを必要とするバグです。
+  Docker ではコンテナ内において、``NO_NEW_PRIVS`` プロセスフラグとその他の仕組みによって setuid バイナリを無効にします。
 
 ..     CVE-2014-4699: A bug in ptrace() could allow privilege escalation. Docker disables ptrace() inside the container using apparmor, seccomp and by dropping CAP_PTRACE. Three times the layers of protection there!
 

--- a/engine/security/non-events.rst
+++ b/engine/security/non-events.rst
@@ -133,9 +133,14 @@ Docker においては、バグに対する軽減対応がなされています�
   ここがおもしろいところで、このケースが、VM よりもコンテナの方が「より安全」と言えるかもしれない点です。
   つまりコンテナよりも VM の方が「より安全」とされる常識に反している例です。
 
-..     CVE-2016-0728: Use-after-free caused by crafted keyctl() calls could lead to privilege escalation. Docker disables keyctl() inside containers using the default seccomp profile.
+.. * [CVE-2016-0728](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0728):
+   Use-after-free caused by crafted `keyctl()` calls could lead to privilege
+   escalation. Docker disables `keyctl()` inside containers using the default
+   seccomp profile.
 
-* `CVE-2016-0728 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0728>`_ ： ``keyctl()`` コールによって作成される use-after-free（使ったあとに解放）により、権限の昇格を引き起こす可能性があります。Docker はデフォルトの seccomp プロファイルを使い、コンテナ内での ``keyctl()`` を無効化します。
+* `CVE-2016-0728 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0728>`_：
+  巧妙な ``keyctl()`` 呼び出しによる開放メモリへの use-after-free 攻撃により、権限昇格を可能とします。
+  Docker ではデフォルトの seccomp プロファイルの利用により、コンテナ内部での ``keyctl()`` を無効にしています。
 
 ..     CVE-2016-2383: A bug in eBPF -- the special in-kernel DSL used to express things like seccomp filters -- allowed arbitrary reads of kernel memory. The bpf() system call is blocked inside Docker containers using (ironically) seccomp.
 

--- a/engine/security/non-events.rst
+++ b/engine/security/non-events.rst
@@ -98,9 +98,15 @@ Docker においては、バグに対する軽減対応がなされています�
   これは setuid バイナリを必要とするバグです。
   Docker ではコンテナ内において、``NO_NEW_PRIVS`` プロセスフラグとその他の仕組みによって setuid バイナリを無効にします。
 
-..     CVE-2014-4699: A bug in ptrace() could allow privilege escalation. Docker disables ptrace() inside the container using apparmor, seccomp and by dropping CAP_PTRACE. Three times the layers of protection there!
+.. * [CVE-2014-4699](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-4699):
+   A bug in `ptrace()` could allow privilege escalation. Docker disables `ptrace()`
+   inside the container using apparmor, seccomp and by dropping `CAP_PTRACE`.
+   Three times the layers of protection there!
 
-* `CVE-2014-4699 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-4699>`_ ： ``ptrace()`` によるバグにより、権限のエスカレーションを引き起こす可能性があります。Docker は apparmor、seccomp を使い、 ``CAP_PTRACE`` で権限を落とすので、コンテナ内での ``ptrace()`` を無効化します。
+* `CVE-2014-4699 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-4699>`_：
+  ``ptrace()`` にあるバグであり、権限昇格を許してしまうものです。
+  Docker では、AppArmor、seccomp、そして ``CAP_PTRACE`` の削除により、コンテナ内での ``ptrace()`` を無効にしています。
+  ここでは三重の防御が行われているわけです。
 
 ..     CVE-2014-9529: A series of crafted keyctl() calls could cause kernel DoS / memory corruption. Docker disables keyctl() inside containers using seccomp.
 

--- a/engine/security/non-events.rst
+++ b/engine/security/non-events.rst
@@ -160,9 +160,9 @@ Docker においては、バグに対する軽減対応がなされています�
   setsockopt の ``IPT_SO_SET_REPLACE``、``ARPT_SO_SET_REPLACE``、``ARPT_SO_SET_REPLACE`` を利用することで、メモリ破壊、ローカル権限昇格を可能にしてしまうバグです。
   これらの引数は ``CAP_NET_ADMIN`` によってブロックでき、Docker ではデフォルトで許可していません。
 
-.. Bugs not mitigated:
+.. Bugs *not* mitigated:
 
-バグがあるものの、未対処（bugs not mitigated）：
+バグ（対応 **なし**）
 
 ..     CVE-2015-3290, 5157: Bugs in the kernel’s non-maskable interrupt handling allowed privilege escalation. Can be exploited in Docker containers because the modify_ldt() system call is not currently blocked using seccomp.
 

--- a/engine/security/non-events.rst
+++ b/engine/security/non-events.rst
@@ -164,9 +164,17 @@ Docker においては、バグに対する軽減対応がなされています�
 
 バグ（対応 **なし**）
 
-..     CVE-2015-3290, 5157: Bugs in the kernel’s non-maskable interrupt handling allowed privilege escalation. Can be exploited in Docker containers because the modify_ldt() system call is not currently blocked using seccomp.
+.. * [CVE-2015-3290](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3290),
+   [5157](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-5157): Bugs in
+   the kernel's non-maskable interrupt handling allowed privilege escalation.
+   Can be exploited in Docker containers because the `modify_ldt()` system call is
+   not currently blocked using seccomp.
 
-* `CVE-2015-3290 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3290>`_  、 `5157 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-5157>`_ ：カーネルの non-masking interrupt handling のバグによるもので、権限の昇格を引き起こします。Docker コンテナでは、現在、 seccomp を使って ``modify_ldt()`` システムコールはブロックしますが、不正な攻撃を受ける可能性があります。
+* `CVE-2015-3290 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3290>`_、
+  `5157 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-5157>`_：
+  カーネルのノンマスカブル割り込み処理におけるバグであり、権限昇格を可能にします。
+  Docker コンテナ内での悪用が可能です。
+  現時点においてシステムコール ``modify_ldt()`` が seccomp を使ってもブロックできないためです。
 
 ..     CVE-2016-5195: A race condition was found in the way the Linux kernel’s memory subsystem handled the copy-on-write (COW) breakage of private read-only memory mappings, which allowed unprivileged local users to gain write access to read-only memory. Also known as “dirty COW.” Partial mitigations: on some operating systems this vulnerability is mitigated by the combination of seccomp filtering of ptrace and the fact that /proc/self/mem is read-only.
 

--- a/engine/security/non-events.rst
+++ b/engine/security/non-events.rst
@@ -29,9 +29,17 @@ Docker においては、バグに対する軽減対応がなされています�
 もっとも Docker コンテナにおいて起動するプロセスでは、たとえバグ修正されなくても、元からぜい弱性があるとは言えません。
 ここではコンテナの起動にあたって、ケーパビリティは追加せず、あるいは ``--privileged`` としては起動していないことを前提とします。
 
-.. The list below is not even remotely complete. Rather, it is a sample of the few bugs we’ve actually noticed to have attracted security review and publicly disclosed vulnerabilities. In all likelihood, the bugs that haven’t been reported far outnumber those that have. Luckily, since Docker’s approach to secure by default through apparmor, seccomp, and dropping capabilities, it likely mitigates unknown bugs just as well as it does known ones.
+.. The list below is not even remotely complete. Rather, it is a sample of the few
+   bugs we've actually noticed to have attracted security review and publicly
+   disclosed vulnerabilities. In all likelihood, the bugs that haven't been
+   reported far outnumber those that have. Luckily, since Docker's approach to
+   secure by default through apparmor, seccomp, and dropping capabilities, it
+   likely mitigates unknown bugs just as well as it does known ones.
 
-以下のリストは完全なものには至っていません。むしろ、いくつかのバグはサンプルであり、私たちが実際にセキュリティ・レビューに対応し、公開された脆弱性に対し、警告を発したものです。すべての可能性やバグは、この一覧にあるよりも遙かに多くの報告があります。幸いにも、Docker のアプローチはデフォルトでセキュア（安全）であるべきというもので、apparmor、seccomp を通したり、ケーパビリティを落とすのもあります。これにより、既に知られているバグだけでなく、未知のバグに対する問題も緩和するでしょう。
+以下は、バグ一覧とはとても言えないものです。
+むしろこれは、ほんのわずかなバグの例にすぎず、セキュリティ・レビューやぜい弱性の公開を行うに至ったことから、バグとして気づいたものでしかありません。
+おそらく報告されているバグよりも、報告されていないバグの方がはるかに多いはずです。
+ただし Docker が採用するセキュアな手法は、デフォルトにおいて AppArmor や Seccomp の利用、そして限定的なケーパビリティの利用を行っているため、既知のバグはもちろん、未知のバグを軽減できる可能性があります。
 
 .. Bugs mitigated:
 


### PR DESCRIPTION
訳修正案 /engine/security/non-events です。よろしくお願いします。

なお当タイトル「Docker security non-events」の ”non-events” についてですが、訳出に迷ったため、修正案コミットの中に修正案は含めていません。現状訳では「その他の Docker セキュリティ」とされています。これは逃げとしては良いと思いますが、うまく訳せるなら原義を伝えるべきであると思います。本来の意味は「Docker セキュリティの中で、どうでもいいもの、とるにたらないもの、さして重要ではないもの」と解釈します。なかなかばっちりと訳出できません。とりあえずの訳案として「重要でない Docker セキュリティ」というものが思いつきます。ただしこれでは「Docker セキュリティ」自体を、考慮しなくても良い取り扱いになってしまい不適切です。いかがでしょう。何かありますか？