### PR TITLE
[リンク先修正] リンク先をwindowsのページに差し替える

### DIFF
--- a/docker-for-windows/install-windows-home.rst
+++ b/docker-for-windows/install-windows-home.rst
@@ -32,7 +32,7 @@ Windows Home マシンで WSL2 バックエンドを使うと、Docker Desktop �
 
 .. Download from Docker Hub
 
-* `Docker Hub からダウンロード <https://hub.docker.com/editions/community/docker-ce-desktop-mac/>`_
+* `Docker Hub からダウンロード <https://hub.docker.com/editions/community/docker-ce-desktop-windows/>`_
 
 .. Docker Desktop on Windows Home offers the following benefits:
 

--- a/docker-for-windows/install.rst
+++ b/docker-for-windows/install.rst
@@ -30,7 +30,7 @@ Docker Desktop for Windows は、Mirosoft Windows 用の Docker `コミュニテ
 
 .. Download from Docker Hub
 
-* `Docker Hub からダウンロード <https://hub.docker.com/editions/community/docker-ce-desktop-mac/>`_
+* `Docker Hub からダウンロード <https://hub.docker.com/editions/community/docker-ce-desktop-windows/>`_
 
 .. By downloading Docker Desktop, you agree to the terms of the Docker Software End User License Agreement and the Docker Data Processing Agreement.
 


### PR DESCRIPTION
"Docker Hub からダウンロード" のリンク先末尾が `docker-ce-desktop-mac` だったため、 `dokcer-ce-desktop-windows` に差し替えを行いました。

ただし、原文（オリジナルのドキュメント）でも同リンク先であれば却下していただいて構いません。

# 参考資料
2020-08-04T14:20+0900 時に確認しましたが、 いずれも「Download from Docker Hub」のリンク先は `https://hub.docker.com/editions/community/docker-ce-desktop-windows/` でした。

* [Install Docker Desktop on Windows | Docker Documentation](https://docs.docker.com/docker-for-windows/install/)
* [Install Docker Desktop on Windows Home | Docker Documentation](https://docs.docker.com/docker-for-windows/install-windows-home/)