### PR TITLE
訳修正案 engine/reference/commandline/commit.rst

### DIFF
--- a/engine/reference/commandline/commit.rst
+++ b/engine/reference/commandline/commit.rst
@@ -41,7 +41,7 @@ commit
 
 .. By default, the container being committed and its processes will be paused while the image is committed. This reduces the likelihood of encountering data corruption during the process of creating the commit. If this behavior is undesired, set the ‘--pause’ option to false.
 
-デフォルトでは、コミットされるコンテナとそれらのプロセスはイメージがコミットされている間は一時的に停止されます。これにより、コミットの作成中にデータの破損が発生する可能性が低くなります。この動作が望ましくない場合は、 ``--pause`` オプションを false に設定してください。
+コミット対象のコンテナとそこに動作するプロセスは、イメージコミット処理の間は、デフォルトで一時停止します。これにより、コミットの作成中にデータの破損が発生する可能性が低くなります。この動作が望ましくない場合は、 ``--pause`` オプションを false に設定してください。
 
 .. The --change option will apply Dockerfile instructions to the image that is created. Supported Dockerfile instructions: CMD|ENTRYPOINT|ENV|EXPOSE|LABEL|ONBUILD|USER|VOLUME|WORKDIR
 

--- a/engine/reference/commandline/commit.rst
+++ b/engine/reference/commandline/commit.rst
@@ -41,7 +41,7 @@ commit
 
 .. By default, the container being committed and its processes will be paused while the image is committed. This reduces the likelihood of encountering data corruption during the process of creating the commit. If this behavior is undesired, set the ‘--pause’ option to false.
 
-デフォルトでは、コンテナをコミットする時、その過程のいてイメージをコミットする間は一時的に停止します。これはコミットする糧において、データ破損が発生する可能性を減らします。この動作を理解しているのであれば、 ``--pause`` オプションを使って無効化もできます。
+デフォルトでは、コミットされるコンテナとそれらのプロセスはイメージがコミットされている間は一時的に停止されます。これにより、コミットの作成中にデータの破損に遭遇する可能性が低くなります。この動作が望ましくない場合は、 ``--pause`` オプションを false に設定してください。
 
 .. The --change option will apply Dockerfile instructions to the image that is created. Supported Dockerfile instructions: CMD|ENTRYPOINT|ENV|EXPOSE|LABEL|ONBUILD|USER|VOLUME|WORKDIR
 

--- a/engine/reference/commandline/commit.rst
+++ b/engine/reference/commandline/commit.rst
@@ -41,7 +41,7 @@ commit
 
 .. By default, the container being committed and its processes will be paused while the image is committed. This reduces the likelihood of encountering data corruption during the process of creating the commit. If this behavior is undesired, set the ‘--pause’ option to false.
 
-デフォルトでは、コミットされるコンテナとそれらのプロセスはイメージがコミットされている間は一時的に停止されます。これにより、コミットの作成中にデータの破損に遭遇する可能性が低くなります。この動作が望ましくない場合は、 ``--pause`` オプションを false に設定してください。
+デフォルトでは、コミットされるコンテナとそれらのプロセスはイメージがコミットされている間は一時的に停止されます。これにより、コミットの作成中にデータの破損が発生する可能性が低くなります。この動作が望ましくない場合は、 ``--pause`` オプションを false に設定してください。
 
 .. The --change option will apply Dockerfile instructions to the image that is created. Supported Dockerfile instructions: CMD|ENTRYPOINT|ENV|EXPOSE|LABEL|ONBUILD|USER|VOLUME|WORKDIR
 


### PR DESCRIPTION
## 修正ファイル

`engine/reference/commandline/commit.rst`

## 修正概要

> その過程のいて  

`過程のいて`

> コミットする糧において、  

`糧`

などの typo がありましたので、修正と併せて該当の一文の訳修正案を提案させて頂きました。
お手隙の際にご確認ください。