### PR TITLE
docker-compose.ymlを修正

### DIFF
--- a/compose/django.rst
+++ b/compose/django.rst
@@ -146,6 +146,10 @@
        services:
          db:
            image: postgres
+           environment:
+            - POSTGRES_DB=postgres
+            - POSTGRES_USER=postgres
+            - POSTGRES_PASSWORD=postgres
          web:
            build: .
            command: python3 manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
#300 の対応
現状のチュートリアルでDjangoの環境構築を行うとpostgresDBのユーザ情報、及びDB名がないためDjangoが環境に接続出来ずにエラーを出力してしまうため、docker-compose.ymlを修正。