### PR TITLE
Enable docker build and publish the image for developers

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,75 @@
+name: Docker
+
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+  # Run tests for any PRs.
+  pull_request:
+
+env:
+  IMAGE_NAME: docs.docker.jp/latex
+
+jobs:
+  # Run tests.
+  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run tests
+        run: |
+          if [ -f docker-compose.test.yml ]; then
+            docker-compose --file docker-compose.test.yml build
+            docker-compose --file docker-compose.test.yml run sut
+          else
+            docker build . --file Dockerfile
+          fi
+
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+    # Ensure test job passes before pushing image.
+    needs: test
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+
+      - name: Log into GitHub Container Registry
+        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image to GitHub Container Registry
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ Dockerを使ってbuildできます。
 
 `build/html` 以下に生成されます。
 
-```
-docker build -t docsdockerjp/latex .
-docker run --rm -v `pwd`:/mnt docsdockerjp/latex make clean html
+```sh
+docker run --rm -v `pwd`:/mnt ghcr.io/zembutsu/docs.docker.jp/latex make clean html
 ```
 
 ## pdf
@@ -24,15 +23,14 @@ docker run --rm -v `pwd`:/mnt docsdockerjp/latex make clean html
 
 `Emergency stop.` を避けるために、あらかじめ `\xe2\x80\x93` (EN DASH)を `--` に変換しておきます。
 
-```
+```sh
 grep -Flr '–' . | xargs -n1 sed -i 's/–/--/g'
 ```
 
 そしてビルド
 
-```
-docker build -t docsdockerjp/latex .
-docker run --rm -v `pwd`:/mnt docsdockerjp/latex make clean latexpdfja
+```sh
+docker run --rm -v `pwd`:/mnt ghcr.io/zembutsu/docs.docker.jp/latex make clean latexpdfja
 ```
 
 ## Archives


### PR DESCRIPTION
Contributors have to have to build the container image from scratch, which takes [400s](https://github.com/tnir/docs.docker.jp/runs/1209690637) (on `Standard_DS2_v2` with 2 vCPU & 7GB mem), but the image is static. Pulling the image from the registry is enough for a (new) contributor to get started with contributions to this project.

- [ ] Create a PAT with `read:packages` and `write:packages` scopes and save it as an Actions secret `CR_PAT`

ローカルでベースイメージをビルドしているが、6分以上かかるので、Registryに公開して、そのイメージを使うようにして、開発者生産性を向上する。