### PR TITLE
fix typo on docker push pages

### DIFF
--- a/engine/reference/commandline/push.rst
+++ b/engine/reference/commandline/push.rst
@@ -24,7 +24,7 @@ push
 
 .. Use docker push to share your images to the Docker Hub registry or to a self-hosted one. Read more about valid image names and tags.
 
-``docker push`` を使うと、イメージを `Docker Hub <https://hub.docker.com/>`_ レジストリや、自分で作成したレジストリで共有できるようになります。 :doc:`詳細は行こうなイメージ名とタグ <tag>` をご覧ください。
+``docker push`` を使うと、イメージを `Docker Hub <https://hub.docker.com/>`_ レジストリや、自分で作成したレジストリで共有できるようになります。 詳細は:doc:`イメージ名とタグ <tag>` をご覧ください。
 
 .. Killing the docker push process, for example by pressing CTRL-c while it is running in a terminal, will terminate the push operation.
 


### PR DESCRIPTION
:doc:`詳細は行こうなイメージ名とタグ <tag>`
とtypoだと思われる記載があったので「行こうな」を削除しました。

また、「詳細は」の文言をリンクから外しました。他のページは「詳細は」にリンクが付与されていないようです。

参考ページ：
http://docs.docker.jp/v17.06/engine/reference/commandline/dockerd.html#insecure-registries