### PR TITLE
fee-basedの翻訳を修正

### DIFF
--- a/get-started/resources.rst
+++ b/get-started/resources.rst
@@ -133,7 +133,7 @@ Docker コミュニティのエキスパートによって作成されました�
 
 .. * Many of the courses are fee-based
 
-* コースのほとんどは無料ベースです。
+* コースのほとんどは有料です。
 
 .. seealso::
 


### PR DESCRIPTION
はじめまして。Dockerを学ぶ際にドキュメントを活用させていただいています。ありがとうございます。
読んでいる中でちょっとだけ気になる箇所があったためPullRequestしました。
[原文](https://docs.docker.com/get-started/resources/)では
```
* Many of the courses are fee-based
```
と書かれていましたので、無料（free-based）ではなく有料（fee-based）ではないかと思います。
よろしくお願いいたします。