### PR TITLE
Composeのインストール時のバージョン指定方法が誤認しやすい

### DIFF
--- a/compose/install.rst
+++ b/compose/install.rst
@@ -198,7 +198,7 @@ Linux における Compose のインストール
 
 .. code-block:: bash
 
-   sudo curl -L https://github.com/docker/compose/releases/download/1.16.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+   sudo curl -L https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
 
 ..     > Use the latest Compose release number in the download command.
        >
@@ -240,7 +240,7 @@ Linux における Compose のインストール
 .. code-block:: bash
 
    $ docker-compose --version
-   docker-compose version 1.16.1, build 1719ceb
+   Docker Compose version v2.6.0
 
 .. raw:: html
 


### PR DESCRIPTION
現在、[Linux における Compose のインストール](https://docs.docker.jp/compose/install.html#linux-compose) に従ってComposeをインストールする場合、手動で最新のバージョン番号に書き換えて実行する必要があります。しかし、現在のバージョン番号には `v` が含まれており、`v2.6.0` のように記述すべきところ、`2.6.0` と書けば良いように伝わってしまうように感じます。

そこで、`v` つきのバージョン指定を例として記載することで、このような勘違いを防げるのではないかと考えています。