### PR TITLE
Update inspect-service.rst

### DIFF
--- a/engine/swarm/swarm-tutorial/inspect-service.rst
+++ b/engine/swarm/swarm-tutorial/inspect-service.rst
@@ -110,9 +110,9 @@ swarm に :doc:`サービスをデプロイ <deploy-service>` したら、swarm 
 
 
 
-..    Run docker service tasks <SERVICE-ID> to see which nodes are running the service:
+..    Run docker service ps <SERVICE-ID> to see which nodes are running the service:
 
-3. ``docker service tasks <サービスID>`` を実行すると、サービスがどのノードで動作しているのか分かります。
+3. ``docker service ps <サービスID>`` を実行すると、サービスがどのノードで動作しているのか分かります。
 
    .. code-block:: bash
    


### PR DESCRIPTION
```docker service ps```が```docker service tasks```になっていました。  
[対応する英語版のサイト](https://docs.docker.com/engine/swarm/swarm-tutorial/inspect-service/)はこちらです