### PR TITLE
CMDとENTRYPOINTの連携の表の誤記を修正

### DIFF
--- a/engine/reference/builder.rst
+++ b/engine/reference/builder.rst
@@ -1870,15 +1870,15 @@ CMD と ENTRYPOINT の連携を理解
      - exec_entry p1_entry
    * - **CMD [“exec_cmd”, “p1_cmd”]**
      - exec_cmd p1_cmd
-     - /bin/sh -c exec_entry p1_entry exec_cmd p1_cmd
+     - /bin/sh -c exec_entry p1_entry
      - exec_entry p1_entry exec_cmd p1_cmd
    * - **CMD [“p1_cmd”, “p2_cmd”]**
      - p1_cmd p2_cmd
-     - /bin/sh -c exec_entry p1_entry p1_cmd p2_cmd
+     - /bin/sh -c exec_entry p1_entry
      - exec_entry p1_entry p1_cmd p2_cmd
    * - **CMD exec_cmd p1_cmd**
      - /bin/sh -c exec_cmd p1_cmd
-     - /bin/sh -c exec_entry p1_entry /bin/sh -c exec_cmd p1_cmd
+     - /bin/sh -c exec_entry p1_entry
      - exec_entry p1_entry /bin/sh -c exec_cmd p1_cmd
 
 ..     Note


### PR DESCRIPTION
実挙動と異なっているようなので修正しました。

`docs.docker.com`の方の表はこのようになっており実挙動と一致しています。
https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact