### PR TITLE
Fix node alpine image version

### DIFF
--- a/get-started/06_bind_mounts.rst
+++ b/get-started/06_bind_mounts.rst
@@ -95,7 +95,7 @@ Node をベースとするアプリケーション `nodemon <https://npmjs.com/p
    
       $ docker run -dp 3000:3000 \
           -w /app -v "$(pwd):/app" \
-          node:12-alpine \
+          node:18-alpine \
           sh -c "yarn install && yarn run dev"
 
    .. If you are using PowerShell then use this command:
@@ -107,7 +107,7 @@ Node をベースとするアプリケーション `nodemon <https://npmjs.com/p
    
       PS> docker run -dp 3000:3000 `
           -w /app -v "$(pwd):/app" `
-          node:12-alpine `
+          node:18-alpine `
           sh -c "yarn install && yarn run dev"
 
    .. If you are using an Apple silicon Mac or another ARM64 device, then use the following command.
@@ -118,14 +118,14 @@ Node をベースとするアプリケーション `nodemon <https://npmjs.com/p
    
       $ docker run -dp 3000:3000 \
            -w /app -v "$(pwd):/app" \
-           node:12-alpine \
+           node:18-alpine \
            sh -c "apk add --no-cache python2 g++ make && yarn install && yarn run dev"
 
 
    * ``-dp 3000:3000`` … 以前と同じです。 :ruby:`デタッチド <detached>` （バックグラウンド）モードで実行し、 :ruby:`ポート割り当て <port mapping>` を作成
    * ``-w /app`` … コマンドを実行する場所として、「 :ruby:`作業ディレクトリ <working directory>` 」またはカレント ディレクトリを指定
    * ``-v "$(pwd):/app"`` … ホスト上にある現在のディレクトリを、コンテナ内の ``/app`` ディレクトリにバインド マウント
-   * ``node:12-alpine`` … 使用するイメージ。これが Dockerfile から作成するアプリ用のベースイメージになるのを意味する
+   * ``node:18-alpine`` … 使用するイメージ。これが Dockerfile から作成するアプリ用のベースイメージになるのを意味する
    * ``sh -c "yarn install && yarn run dev"`` … （コンテナで）実行するコマンド。 ``sh`` を使って開始し（alpine には ``bash`` がないため）、全ての依存関係をインストールするため ``yarn install`` を実行し、それから ``yarn run dev`` を実行。 ``package.json`` があれば確認し、それから ``dev`` スクリプトが ``nodemon`` を開始する
 
 .. You can watch the logs using docker logs. You’ll know you’re ready to go when you see this:
@@ -136,7 +136,7 @@ Node をベースとするアプリケーション `nodemon <https://npmjs.com/p
    
       $ docker logs -f <container-id>
       nodemon src/index.js
-      [nodemon] 1.19.2
+      [nodemon] 2.0.20
       [nodemon] to restart at any time, enter `rs`
       [nodemon] watching dir(s): *.*
       [nodemon] starting `node src/index.js`

--- a/get-started/07_multi_container.rst
+++ b/get-started/07_multi_container.rst
@@ -299,7 +299,7 @@ todo アプリでは、 MySQL へ接続する設定を指定するため、い�
         -e MYSQL_USER=root \
         -e MYSQL_PASSWORD=secret \
         -e MYSQL_DB=todos \
-        node:12-alpine \
+        node:18-alpine \
         sh -c "yarn install && yarn run dev"
 
    .. If you are using Windows then use this command in PowerShell.
@@ -315,7 +315,7 @@ todo アプリでは、 MySQL へ接続する設定を指定するため、い�
         -e MYSQL_USER=root `
         -e MYSQL_PASSWORD=secret `
         -e MYSQL_DB=todos `
-        node:12-alpine `
+        node:18-alpine `
         sh -c "yarn install && yarn run dev"
 
 .. If we look at the logs for the container (docker logs <container-id>), we should see a message indicating it’s using the mysql database.

--- a/get-started/08_using_compose.rst
+++ b/get-started/08_using_compose.rst
@@ -100,7 +100,7 @@ Compose ファイルの作成
      -e MYSQL_USER=root \
      -e MYSQL_PASSWORD=secret \
      -e MYSQL_DB=todos \
-     node:12-alpine \
+     node:18-alpine \
      sh -c "yarn install && yarn run dev"
 
 PowerShell の場合は、こちらのコマンドを使っていました。
@@ -114,7 +114,7 @@ PowerShell の場合は、こちらのコマンドを使っていました。
      -e MYSQL_USER=root `
      -e MYSQL_PASSWORD=secret `
      -e MYSQL_DB=todos `
-     node:12-alpine `
+     node:18-alpine `
      sh -c "yarn install && yarn run dev"
 
 .. First, let’s define the service entry and the image for the container. We can pick any name for the service. The name will automatically become a network alias, which will be useful when defining our MySQL service.
@@ -127,7 +127,7 @@ PowerShell の場合は、こちらのコマンドを使っていました。
       
       services:
         app:
-          image: node:12-alpine
+          image: node:18-alpine
 
 .. Typically, you will see the command close to the image definition, although there is no requirement on ordering. So, let’s go ahead and move that into our file.
 
@@ -139,7 +139,7 @@ PowerShell の場合は、こちらのコマンドを使っていました。
       
       services:
         app:
-          image: node:12-alpine
+          image: node:18-alpine
           command: sh -c "yarn install && yarn run dev"
 
 .. Let’s migrate the -p 3000:3000 part of the command by defining the ports for the service. We will use the short syntax here, but there is also a more verbose long syntax available as well.
@@ -152,7 +152,7 @@ PowerShell の場合は、こちらのコマンドを使っていました。
       
       services:
         app:
-          image: node:12-alpine
+          image: node:18-alpine
           command: sh -c "yarn install && yarn run dev"
           ports:
             - 3000:3000
@@ -171,7 +171,7 @@ PowerShell の場合は、こちらのコマンドを使っていました。
       
       services:
         app:
-          image: node:12-alpine
+          image: node:18-alpine
           command: sh -c "yarn install && yarn run dev"
           ports:
             - 3000:3000
@@ -189,7 +189,7 @@ PowerShell の場合は、こちらのコマンドを使っていました。
       
       services:
         app:
-          image: node:12-alpine
+          image: node:18-alpine
           command: sh -c "yarn install && yarn run dev"
           ports:
             - 3000:3000
@@ -299,7 +299,7 @@ PowerShell の場合は、以下のコマンドを使います。
    
    services:
      app:
-       image: node:12-alpine
+       image: node:18-alpine
        command: sh -c "yarn install && yarn run dev"
        ports:
          - 3000:3000


### PR DESCRIPTION
現在のドキュメント通りに実行すると、以下のエラーが出ました。

```
➜  app git:(master) ✗ docker logs -f 52b8243c7f4d
yarn install v1.22.18
[1/4] Resolving packages...
[2/4] Fetching packages...
error jest@29.3.1: The engine "node" is incompatible with this module. Expected version "^14.15.0 || ^16.10.0 || >=18.0.0". Got "12.22.12"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
Node.js 12 系では jest と互換性がないようです。そこで、[PR 作成時点での LTS](https://github.com/nodejs/release#release-schedule) である 18 系にイメージを変更しました。 

変更点はローカル開発環境で動作確認済みです。

また、変更点は本家（Original version）と同じであることも確認できました。
https://docs.docker.com/get-started/06_bind_mounts/#run-your-app-in-a-development-container
https://docs.docker.com/get-started/07_multi_container/#run-your-app-with-mysql
https://docs.docker.com/get-started/08_using_compose/#define-the-app-service

## 未変更点
Part9 「イメージ構築のベストプラクティス」は未対応です。
https://docs.docker.jp/get-started/09_image_best.html#layer-caching

- 元から前回までの Part の内容をうまく引き継げていない気がする
- ログの内容まで忠実に変更しようとすると変更が多くなりそう

と判断して変更しておりません。

とはいえ `node:12-alpine` だと動かないことには変わりはないので、とりあえずイメージのバージョンだけ直せばいいのであれば対応します。