### PR TITLE
fix typo

### DIFF
--- a/get-started/05_persisting_data.rst
+++ b/get-started/05_persisting_data.rst
@@ -75,7 +75,7 @@ DB の保持
 
    .. If you prefer the command line you can use the docker exec command to do the same. You need to get the container’s ID (use docker ps to get it) and get the content with the following command.
 
-   ``docker eec`` コマンドを使う方が好きでしたら、同じようにできます。そのためにはコンテナ ID の確認が必要です。それから、以下のコマンドでファイル内容を表示します。
+   ``docker exec`` コマンドを使う方が好きでしたら、同じようにできます。そのためにはコンテナ ID の確認が必要です。それから、以下のコマンドでファイル内容を表示します。
 
    .. code-block:: bash
    

--- a/get-started/09_image_best.rst
+++ b/get-started/09_image_best.rst
@@ -198,7 +198,7 @@
 
    .. .dockerignore files are an easy way to selectively copy only image relevant files. You can read more about this here. In this case, the node_modules folder should be omitted in the second COPY step because otherwise, it would possibly overwrite files which were created by the command in the RUN step. For further details on why this is recommended for Node.js applications and other best practices, have a look at their guide on Dockerizing a Node.js web app.
 
-   イメージに関係あるファイルだけ選んでコピーするには、 ``.dockerignore`` ファイルの利用が簡単です。 :ref:`こちら <dockerignore-file>` で詳しく読めます。今回の場合、２つめの ``COPY`` ステップで ``node_modulers`` フォルダは無視されます。これは、そうしなければ、 ``RUN`` ステップ中の命令で作成されるファイルにより、上書きされる可能性があるためです。どうして Node.js アプリケーションにこのような推奨をするのかや、他のペストプラクティスといった詳細は、Node.js のガイド `Dockerizing a Node.js web app <https://nodejs.org/en/docs/guides/nodejs-docker-webapp/>`_ をご覧ください。
+   イメージに関係あるファイルだけ選んでコピーするには、 ``.dockerignore`` ファイルの利用が簡単です。 :ref:`こちら <dockerignore-file>` で詳しく読めます。今回の場合、２つめの ``COPY`` ステップで ``node_modulers`` フォルダは無視されます。これは、そうしなければ、 ``RUN`` ステップ中の命令で作成されるファイルにより、上書きされる可能性があるためです。どうして Node.js アプリケーションにこのような推奨をするのかや、他のベストプラクティスといった詳細は、Node.js のガイド `Dockerizing a Node.js web app <https://nodejs.org/en/docs/guides/nodejs-docker-webapp/>`_ をご覧ください。
 
 .. Build a new image using docker build.
 


### PR DESCRIPTION
"docker eec" -> "docker exec"
「ペストプラクティス」->「ベストプラクティス」
