### PR TITLE
Sphinxテーマとスタイルの更新

### DIFF
--- a/_static/custom_style.css
+++ b/_static/custom_style.css
@@ -1,3 +1,11 @@
 .wy-nav-content {
    max-width: 850px
 }
+
+/* see also のアイコンを変更 */
+div.seealso > .admonition-title:before {
+    content: "\f02d";
+    font-family: "FontAwesome";
+    font-weight: 900;
+    margin-right: 0.5em;
+}

--- a/conf.py
+++ b/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Docker-docs-ja'
-copyright = u'2015-2022, Docker Docs Translation Ja-Jp Project'
+copyright = u'2015-2023, Docker Docs Translation Ja-Jp Project'
 author = u'Docker Docs Translation Ja-Jp Project'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -122,15 +122,35 @@ html_theme = 'sphinx_rtd_theme'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+html_theme_options = {
+    'logo_only': False,
+    'display_version': True,
+    'prev_next_buttons_location': 'bottom',
+    'style_external_links': True,
+    'collapse_navigation': True,
+    'sticky_navigation': True,
+    'navigation_depth': 5,
+    'includehidden': True,
+    'titles_only': False,
+}
+
+# 「Edit on GitHub」の表示
+# https://docs.readthedocs.io/en/stable/guides/edit-source-links-sphinx.html
+html_context = {
+    "display_github": True,
+    "github_user": "zembutsu",
+    "github_repo": "docs.docker.jp",
+    "github_version": "v23.0",
+    "conf_py_path": "/",
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
 #html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-html_theme_path = ['./_themes/']
+#html_theme_path = ['./_themes/']
 
-#def setup(app):
-#	    app.add_stylesheet('custom_style.css')
+def setup(app):
+	    app.add_css_file('custom_style.css')
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/index.rst
+++ b/index.rst
@@ -133,3 +133,7 @@ Docs archive
    v1.11 <http://docs.docker.jp/v1.11/>
    v1.10 <http://docs.docker.jp/v1.10/>
    v1.9 <http://docs.docker.jp/v1.9/>
+
+.. seealso::
+
+  Docker 公式ドキュメント  https://docs.docker.com/


### PR DESCRIPTION
 `/_themes` 以下ローカルのテーマを読み込ませていましたが、パッケージとして新しいバージョンを取り込み可能なため、切り離します。あわせて、必要な追加設定（GitHubのリポジトリ情報を conf.py に追記するなど）をしました。

この変更により RST ファイルの書き換えが発生する見込みです。順次確認し、反映していく予定です。