### PR TITLE
fix typo

### DIFF
--- a/get-started/05_persisting_data.rst
+++ b/get-started/05_persisting_data.rst
@@ -127,7 +127,7 @@ todo データの保持
 
 .. By default, the todo app stores its data in a SQLite Database at /etc/todos/todo.db in the container’s filesystem. If you’re not familiar with SQLite, no worries! It’s simply a relational database in which all of the data is stored in a single file. While this isn’t the best for large-scale applications, it works for small demos. We’ll talk about switching this to a different database engine later.
 
-デフォルトでは、todo アプリが自身のデータを保存するのは、コンテナ用ファイルシステム内で ``/etc/todo/todo.db`` にある `SQLite Databese <https://www.sqlite.org/index.html>`_ の中です。SQLite に不慣れでも、心配は要りません！ これはシンプルなリレーショナル データベースで、１つのファイル内に全てのデータを保存します。大きくスケールするアプリケーションには最良ではありませんが、小さなデモには効果的です。これを他のデータベースエンジンに切り替える方法は、後ほどお伝えします。
+デフォルトでは、todo アプリが自身のデータを保存するのは、コンテナ用ファイルシステム内で ``/etc/todos/todo.db`` にある `SQLite Databese <https://www.sqlite.org/index.html>`_ の中です。SQLite に不慣れでも、心配は要りません！ これはシンプルなリレーショナル データベースで、１つのファイル内に全てのデータを保存します。大きくスケールするアプリケーションには最良ではありませんが、小さなデモには効果的です。これを他のデータベースエンジンに切り替える方法は、後ほどお伝えします。
 
 .. With the database being a single file, if we can persist that file on the host and make it available to the next container, it should be able to pick up where the last one left off. By creating a volume and attaching (often called “mounting”) it to the directory the data is stored in, we can persist the data. As our container writes to the todo.db file, it will be persisted to the host in the volume.
 


### PR DESCRIPTION
https://docs.docker.jp/index.html
とてもわかりやすかったです！　ありがとうございます。

typoを見つけましたのでプルリクを送ります。
v24.0 から派生させて修正をつくりました。
派生元、マージ先に誤りがありましたら作り直しますのでご連絡をくださいませ。

---

ただ、申し訳ありませんが確認が不十分でして、htmlを出力しての確認ができてはおりません。
別のIssueを立てたほうがいいかもしれませんがここで状況をお伝えしておきます。

- `docker run --rm -v `pwd`:/mnt ghcr.io/zembutsu/docs.docker.jp/latex make clean latexpdfja`は、「docker: Error response from daemon: Head "https://ghcr.io/v2/zembutsu/docs.docker.jp/latex/manifests/latest": denied.」でした。https://github.com/zembutsu?tab=packages を見る限り公開されているものではないようにおもいました。（ghcr.ioの設定が不足しているなど、私が勘違いしているだけかもしれません:pray:）
- `Dockerfile`がありましたのでbuildを試みましたが以下のエラーとなりました。ビルドに使ったコマンドは、 `docker build -t docs.docker.jp .`です。

## macOS Ventura 13.5.1(M2)

```
docker -v
Docker version 24.0.5, build ced0996

docker build -t docs.docker.jp .
(略)
2569.6 E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/libx/libxext/libxext6_1.3.3-1_arm64.deb  Connection timed out [IP: 185.125.190.39 80]
2569.6 
2569.6 E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/universe/f/fonts-ipaexfont/fonts-ipaexfont-gothic_00301-2ubuntu2_all.deb  Connection timed out [IP: 185.125.190.39 80]
2569.6 
2569.6 E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/libx/libxfixes/libxfixes3_5.0.1-2_arm64.deb  Connection timed out [IP: 185.125.190.39 80]
2569.6 
2569.6 E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/universe/d/dvi2ps-fontdata/dvi2ps-fontdata-ja_1.0.1-3_all.deb  Connection timed out [IP: 185.125.190.39 80]
2569.6 
2569.6 E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/f/fonts-font-awesome/fonts-font-awesome_4.5.0~dfsg-1_all.deb  Connection timed out [IP: 185.125.190.39 80]
2569.6 
2569.6 E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/universe/f/fonts-lobstertwo/fonts-lobster_2.0-2_all.deb  Connection timed out [IP: 185.125.190.39 80]
2569.6 
2569.6 E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/universe/g/gv/gv_3.7.4-1_arm64.deb  Connection timed out [IP: 185.125.190.39 80]
2569.6 
2569.6 E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/universe/l/latex-cjk-chinese-arphic/latex-cjk-chinese-arphic-bkai00mp_1.23_all.deb  Connection timed out [IP: 185.125.190.39 80]
2569.6 
2569.6 E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/m/mesa/libglapi-mesa_18.0.5-0ubuntu0~16.04.1_arm64.deb  Connection timed out [IP: 185.125.190.39 80]
2569.6 
2569.6 E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
2569.6 Fetched 1297 MB in 42min 46s (505 kB/s)
------
Dockerfile:14
--------------------
  13 |     
  14 | >>> RUN apt-get -y update \
  15 | >>>         && apt-get -y install \
  16 | >>>             texlive \
  17 | >>>             texlive-lang-cjk \
  18 | >>>             xdvik-ja \
  19 | >>>             dvipsk-ja \
  20 | >>>             gv \
  21 | >>>             texlive-fonts-recommended \
  22 | >>>             texlive-fonts-extra \
  23 | >>>         && apt-get clean
  24 |     RUN apt-get -y update \
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get -y update         && apt-get -y install             texlive             texlive-lang-cjk             xdvik-ja             dvipsk-ja             gv             texlive-fonts-recommended             texlive-fonts-extra         && apt-get clean" did not complete successfully: exit code: 100
```

## WSL2 Ubuntu 22.04.2 LTS

```
docker -v
Docker version 24.0.2, build cb74dfc

docker build -t docs.docker.jp .
(略)
 => ERROR [6/7] RUN pip install Sphinx==1.4.8                                                                      2.6s
------
 > [6/7] RUN pip install Sphinx==1.4.8:
0.618 Collecting Sphinx==1.4.8
1.249   Downloading https://files.pythonhosted.org/packages/b5/db/a93672c16532ee4066cebe47f9a72e774c9be44b976110a7a16cecc016fd/Sphinx-1.4.8-py2.py3-none-any.whl (1.6MB)
1.753 Collecting alabaster<0.8,>=0.7 (from Sphinx==1.4.8)
2.040   Downloading https://files.pythonhosted.org/packages/94/71/a8ee96d1fd95ca04a0d2e2d9c4081dac4c2d2b12f7ddb899c8cb9bfd1532/alabaster-0.7.13.tar.gz
2.111     Complete output from command python setup.py egg_info:
2.111     Traceback (most recent call last):
2.111       File "<string>", line 1, in <module>
2.111       File "/tmp/pip-build-3zKgpZ/alabaster/setup.py", line 27
2.111         "Source": f"https://github.com/{code_ns}",
2.111                                                 ^
2.111     SyntaxError: invalid syntax
2.111
2.111     ----------------------------------------
2.123 Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-3zKgpZ/alabaster/
2.587 You are using pip version 8.1.1, however version 23.2.1 is available.
2.587 You should consider upgrading via the 'pip install --upgrade pip' command.
------
Dockerfile:29
--------------------
  27 |                 python-pip \
  28 |             && apt-get clean
  29 | >>> RUN pip install Sphinx==1.4.8
  30 |
  31 |     VOLUME ["/mnt"]
--------------------
ERROR: failed to solve: process "/bin/sh -c pip install Sphinx==1.4.8" did not complete successfully: exit code: 1
```
