### PR TITLE
Fixed typo in link to `docker restart`

### DIFF
--- a/engine/reference/commandline/restart.rst
+++ b/engine/reference/commandline/restart.rst
@@ -84,5 +84,5 @@ docker restart
 .. seealso:: 
 
    docker restart
-      https://docs.docker.com/engine/reference/commandline/resatart/
+      https://docs.docker.com/engine/reference/commandline/restart/
 


### PR DESCRIPTION
- リンク切れ & typo があったので修正しました

修正後の確認方法がよくわかっておらず、`resatart` で grep して見つけたところを直したのですが、
もしほかにも直すべきところがあればご教示いただけるとたすかります。 🙏 