### PR TITLE
fix typo

### DIFF
--- a/engine/reference/commandline/docker.rst
+++ b/engine/reference/commandline/docker.rst
@@ -84,7 +84,7 @@ Docker CLI のベース（基本）コマンドです。
    * - :doc:`docker network <network>`
      - ネットワークの管理
    * - :doc:`docker node <node>`
-     - Swarm ノード音管理
+     - Swarm ノードの管理
    * - :doc:`docker pause <pause>`
      - 1つまたは複数のコンテナ内の全プロセスを一次停止
    * - :doc:`docker plugin <plugin>`
@@ -96,7 +96,7 @@ Docker CLI のベース（基本）コマンドです。
    * - :doc:`docker pull <pull>`
      - レジストリからイメージやリポジトリを取得
    * - :doc:`docker push <push>`
-     - じれストリにイメージやレプジトリを送信
+     - レジストリにイメージやリポジトリを送信
    * - :doc:`docker rename <rename>`
      - コンテナの名前を変更
    * - :doc:`docker restart <restart>`


### PR DESCRIPTION
### Overview
Docker CLI のベース（基本）コマンドのページ ( https://docs.docker.jp/engine/reference/commandline/docker.html )における次のタイポを修正します。
- ノード音管理 -> ノードの管理
  - 「ノードを管理」でも良さそうですが、他の項目と合わせました。
- じれストリ -> レジストリ
- レプジトリ -> リポジトリ

### Other consideration
READMEに「デフォルトのブランチ v23.0 に対してお願いいたします。」とありましたが、現在は`v24.0`がデフォルトブランチになっているようでしたので、`v24.0`に向けてPRを作成しています。（他の方のマージ済PRを見たところ同様の記載があったことからも問題なさそうかと思っています）

```sh
~/docs.docker.jp (v24.0)
$ git remote show origin | grep 'HEAD branch'
  HEAD branch: v24.0
```