### PR TITLE
Fix compose_up.rst

### DIFF
--- a/engine/reference/commandline/compose_up.rst
+++ b/engine/reference/commandline/compose_up.rst
@@ -27,10 +27,7 @@ docker compose up
 
 コンテナを作成し、開始します。
 
-
-サービスを停止します。
-
-.. _compose_stop-usage:
+.. _compose_up-usage:
 
 使い方
 ==========


### PR DESCRIPTION
不自然に置かれた「サービスを停止します。」を削除。

`compose up` のページなので、`compose_stop` を `compose_up` に変更。