### PR TITLE
fix: fix inline code block style

### DIFF
--- a/config/daemon/systemd.rst
+++ b/config/daemon/systemd.rst
@@ -251,7 +251,7 @@ rootless モード
 
 .. Create a file named ~/.config/systemd/user/docker.service.d/http-proxy.conf that adds the HTTP_PROXY environment variable:
 
-2.  ``~/.config/systemd/user/docker.service.d/http-proxy.conf `` というファイルを生成して、そこに環境変数 ``HTTP_PROXY`` の設定を書きます。
+2.  ``~/.config/systemd/user/docker.service.d/http-proxy.conf`` というファイルを生成して、そこに環境変数 ``HTTP_PROXY`` の設定を書きます。
 
    ..  ```conf
        [Service]


### PR DESCRIPTION
ref: https://www.sphinx-doc.org/ja/master/usage/restructuredtext/basics.html#inline-markup

コードブロックが崩れ、意図しない部分も`code`要素になっていたため修正。

修正前は以下のようなHTMLが生成されていました。


```html
<code class="docutils literal notranslate">
  <span class="pre">~/.config/systemd/user/docker.service.d/http-proxy.conf</span> <span class="pre">``</span> <span class="pre">というファイルを生成して、そこに環境変数</span> <span class="pre">``HTTP_PROXY</span>
</code>
```