### PR TITLE
fix: typo in `reference/commandline/compose.rst`

### DIFF
--- a/engine/reference/commandline/compose.rst
+++ b/engine/reference/commandline/compose.rst
@@ -180,7 +180,7 @@ profile でオプションのサービスを有効化
 
 .. Setting the COMPOSE_FILE environment variable is equivalent to passing the -f flag, COMPOSE_PROJECT_NAME environment variable does the same for to the -p flag, and so does COMPOSE_PROFILES environment variable for to the --profile flag.
 
-``COMPOSE_FILE`` 環境変数の設定は、 ``-f``` フラグを渡すのと同じです。 ``COMPOSE_PROJECT_NAME`` 環境変数は、 ``-p`` フラグを渡すのと同じです。さらに ``COMPOSE_PROFILES`` 環境変数は、 ``--profile`` フラグを渡すのと同じです。
+``COMPOSE_FILE`` 環境変数の設定は、 ``-f`` フラグを渡すのと同じです。 ``COMPOSE_PROJECT_NAME`` 環境変数は、 ``-p`` フラグを渡すのと同じです。さらに ``COMPOSE_PROFILES`` 環境変数は、 ``--profile`` フラグを渡すのと同じです。
 
 .. If flags are explicitly set on command line, associated environment variable is ignored
 


### PR DESCRIPTION
　翻訳助かっております。
　reStructuredText のシンタックス修正しました。
　お手隙でご確認お願いします。