### PR TITLE
fix: typo in login cmd

### DIFF
--- a/engine/reference/commandline/login.rst
+++ b/engine/reference/commandline/login.rst
@@ -192,7 +192,7 @@ Docker Engine はユーザの認証情報を外部の認証情報ストアに保
 
 .. Credential helpers can be any program or script that follows a very simple protocol. This protocol is heavily inspired by Git, but it differs in the information shared.
 
-: ruby:`認証情報ヘルパー <credential helper>` は、どのようなプログラムやスクリプトでも扱える非常にシンプルなプロトコルです。このプロトコルは Git のアイディアに強く影響を受けていますが、情報を共有する仕組みは違います。
+:ruby:`認証情報ヘルパー <credential helper>` は、どのようなプログラムやスクリプトでも扱える非常にシンプルなプロトコルです。このプロトコルは Git のアイディアに強く影響を受けていますが、情報を共有する仕組みは違います。
 
 .. The helpers always use the first argument in the command to identify the action. There are only three possible values for that argument: store, get, and erase.
 


### PR DESCRIPTION
I found a typo in `docker login` cmd. Really tiny fix... 

ref:
![image](https://github.com/user-attachments/assets/5645dc25-8ccb-4946-9372-25f22663fabc)
